### PR TITLE
Stats Page: Publishing Heatmap, Writing Streak, Post Analytics Dashboard

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,7 @@
 ---
 const navLinks = [
   { label: 'Blog', href: '/blog' },
+  { label: 'Stats', href: '/stats' },
   { label: 'Categories', href: '/categories' },
   { label: 'Tags', href: '/tags' },
   { label: 'Projects', href: '/projects' },

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,11 @@ export function getReadingTime(content: string): string {
     return stats.text; // "5 min read"
 }
 
+export function getWordCount(content: string): number {
+    const stats = readingTime(content);
+    return stats.words;
+}
+
 export function formatDate(date: Date): string {
     return new Intl.DateTimeFormat('en-US', {
         year: 'numeric',

--- a/src/pages/stats.astro
+++ b/src/pages/stats.astro
@@ -1,0 +1,695 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import { getCollection } from "astro:content";
+import { getWordCount } from "../lib/utils";
+
+// 1. Fetch posts
+const allPosts = await getCollection("blog", ({ data }) => !data.draft);
+const sortedPosts = allPosts.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+
+// 2. Summary Stats
+const totalPosts = allPosts.length;
+
+const now = new Date();
+const currentMonth = now.getMonth();
+const currentYear = now.getFullYear();
+const postsThisMonth = allPosts.filter(p => {
+  const d = p.data.date;
+  return d.getMonth() === currentMonth && d.getFullYear() === currentYear;
+}).length;
+
+const totalWords = allPosts.reduce((acc, p) => acc + (p.body ? getWordCount(p.body) : 0), 0);
+const uniqueCategories = [...new Set(allPosts.map(p => p.data.category))].length;
+
+// 3. Heatmap Data Preparation
+// Format: [{ date: "YYYY-MM-DD", value: count }]
+const heatmapData = Object.entries(allPosts.reduce((acc: Record<string, number>, p) => {
+  const dateStr = p.data.date.toISOString().split('T')[0];
+  acc[dateStr] = (acc[dateStr] || 0) + 1;
+  return acc;
+}, {})).map(([date, value]) => ({ date, value }));
+
+// 4. Streak Calculation
+const postDates = [...new Set(allPosts.map(p => p.data.date.toISOString().split('T')[0]))].sort().reverse();
+
+function calculateStreaks(dates: string[]) {
+  if (dates.length === 0) return { current: 0, longest: 0 };
+  
+  let current = 0;
+  let longest = 0;
+  let tempStreak = 0;
+  
+  const today = new Date().toISOString().split('T')[0];
+  const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+  
+  // Check if current streak is still active (today or yesterday)
+  let isActive = dates[0] === today || dates[0] === yesterday;
+  
+  for (let i = 0; i < dates.length; i++) {
+    const currentDay = new Date(dates[i]);
+    const nextDay = dates[i+1] ? new Date(dates[i+1]) : null;
+    
+    tempStreak++;
+    
+    if (nextDay) {
+      const diffTime = Math.abs(currentDay.getTime() - nextDay.getTime());
+      const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+      
+      if (diffDays > 1) {
+        if (isActive && current === 0) current = tempStreak;
+        longest = Math.max(longest, tempStreak);
+        tempStreak = 0;
+        isActive = false;
+      }
+    } else {
+      if (isActive && current === 0) current = tempStreak;
+      longest = Math.max(longest, tempStreak);
+    }
+  }
+  
+  return { current, longest };
+}
+
+const streaks = calculateStreaks(postDates);
+
+// 5. Category distribution
+const categoryData = allPosts.reduce((acc: Record<string, number>, p) => {
+  acc[p.data.category] = (acc[p.data.category] || 0) + 1;
+  return acc;
+}, {});
+const sortedCategories = Object.entries(categoryData).sort((a, b) => b[1] - a[1]);
+const maxCategoryCount = Math.max(...Object.values(categoryData));
+
+// 6. Monthly history (Last 12 months from NOW or from latest post)
+const endDate = now;
+const startDate = new Date(Math.min(now.getTime() - (365 * 24 * 60 * 60 * 1000), sortedPosts[sortedPosts.length - 1]?.data.date.getTime() || now.getTime()));
+
+const monthlyHistoryMonths = [];
+let monthCursor = new Date(endDate);
+monthCursor.setDate(1);
+
+for (let i = 0; i < 15; i++) { // Show 15 months to be safe
+  monthlyHistoryMonths.push({
+    month: monthCursor.toLocaleString('default', { month: 'short' }),
+    year: monthCursor.getFullYear(),
+    key: `${monthCursor.getFullYear()}-${String(monthCursor.getMonth() + 1).padStart(2, '0')}`
+  });
+  monthCursor.setMonth(monthCursor.getMonth() - 1);
+  if (monthCursor.getTime() < startDate.getTime() && monthlyHistoryMonths.length >= 12) break;
+}
+monthlyHistoryMonths.reverse();
+
+const monthlyData = monthlyHistoryMonths.map(m => {
+  const count = allPosts.filter(p => {
+    const pd = p.data.date;
+    return pd.getFullYear() === m.year && (pd.getMonth() + 1) === parseInt(m.key.split('-')[1]);
+  }).length;
+  return { ...m, count };
+});
+const maxMonthlyCount = Math.max(...monthlyData.map(m => m.count), 1);
+
+// 7. Top Tags
+const tagData = allPosts.flatMap(p => p.data.tags).reduce((acc: Record<string, number>, tag) => {
+  acc[tag] = (acc[tag] || 0) + 1;
+  return acc;
+}, {});
+const topTags = Object.entries(tagData).sort((a, b) => b[1] - a[1]).slice(0, 10);
+
+// 8. Motivational Banner
+const lastPostDate = sortedPosts[0]?.data.date || new Date(0);
+const daysSinceLastPost = Math.floor((now.getTime() - lastPostDate.getTime()) / (1000 * 60 * 60 * 24));
+
+let motivation = { text: "", icon: "" };
+if (daysSinceLastPost < 7) {
+  motivation = { text: "You're on a roll! Keep going 🚀", icon: "🔥" };
+} else if (daysSinceLastPost <= 14) {
+  motivation = { text: "Time to write something! Your readers are waiting.", icon: "✍️" };
+} else {
+  motivation = { text: "It's been a while. Even a short post counts. 💪", icon: "🗓️" };
+}
+---
+
+<BaseLayout title="Writing Stats" description="Analytics and publishing history for nishanthm.dev">
+  <main class="stats-page">
+    <div class="stats-container">
+      <!-- Header -->
+      <header class="stats-header anim-fade">
+        <h1 class="gradient-text">Writing Stats</h1>
+        <p class="stats-subtitle">Visualizing consistency, growth, and the journey of building in public.</p>
+      </header>
+
+      <!-- Summary Cards -->
+      <div class="stats-grid summary-cards">
+        <div class="stat-card anim-fade" style="--delay: 1">
+          <span class="stat-value" data-target={totalPosts}>{totalPosts}</span>
+          <span class="stat-label">Total Posts</span>
+        </div>
+        <div class="stat-card anim-fade" style="--delay: 2">
+          <span class="stat-value" data-target={postsThisMonth}>{postsThisMonth}</span>
+          <span class="stat-label">This Month</span>
+        </div>
+        <div class="stat-card anim-fade" style="--delay: 3">
+          <span class="stat-value" data-target={totalWords}>{totalWords.toLocaleString()}</span>
+          <span class="stat-label">Total Words</span>
+        </div>
+        <div class="stat-card anim-fade" style="--delay: 4">
+          <span class="stat-value" data-target={uniqueCategories}>{uniqueCategories}</span>
+          <span class="stat-label">Categories</span>
+        </div>
+      </div>
+
+      <section class="stats-section heatmap-section anim-fade" style="--delay: 5">
+        <h2 class="section-title">Publishing Heatmap</h2>
+        <div class="heatmap-wrapper">
+          <div id="cal-heatmap"></div>
+          <div id="heatmap-legend" class="heatmap-legend"></div>
+        </div>
+      </section>
+
+      <div class="stats-row">
+        <!-- Streaks -->
+        <div class="stats-col anim-fade" style="--delay: 6">
+          <h2 class="section-title">Writing Streaks</h2>
+          <div class="streak-cards">
+            <div class="streak-card current">
+              <div class="streak-icon">🔥</div>
+              <div class="streak-info">
+                <span class="streak-value">{streaks.current}</span>
+                <span class="streak-label">Day Streak</span>
+              </div>
+            </div>
+            <div class="streak-card longest">
+              <div class="streak-icon">🏆</div>
+              <div class="streak-info">
+                <span class="streak-value">{streaks.longest}</span>
+                <span class="streak-label">Best Streak</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Category Distribution -->
+        <div class="stats-col anim-fade" style="--delay: 7">
+          <h2 class="section-title">By Category</h2>
+          <div class="category-bars">
+            {sortedCategories.map(([cat, count]) => (
+              <div class="bar-row">
+                <div class="bar-info">
+                  <span class="bar-label">{cat}</span>
+                  <span class="bar-count">{count}</span>
+                </div>
+                <div class="bar-container">
+                  <div 
+                    class="bar-fill" 
+                    style={`width: ${(count / maxCategoryCount) * 100}%; background-color: var(--color-${cat.toLowerCase()});`}
+                  ></div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div class="stats-row">
+        <!-- Monthly History -->
+        <div class="stats-col anim-fade" style="--delay: 8">
+          <h2 class="section-title">Monthly Activity</h2>
+          <div class="monthly-chart">
+            {monthlyData.map(m => (
+              <div class="month-column">
+                <div class="column-wrapper">
+                  <div 
+                    class="column-fill" 
+                    style={`height: ${(m.count / maxMonthlyCount) * 100}%;`}
+                    data-tooltip={`${m.count} posts in ${m.month} ${m.year}`}
+                  ></div>
+                </div>
+                <span class="month-label">{m.month}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <!-- Top Tags -->
+        <div class="stats-col anim-fade" style="--delay: 9">
+          <h2 class="section-title">Top Tags</h2>
+          <div class="tag-list">
+            {topTags.map(([tag, count], index) => (
+              <div class="tag-rank-item">
+                <span class="tag-rank">#{index + 1}</span>
+                <span class="tag-name">{tag}</span>
+                <span class="tag-count-pill">{count}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <!-- Motivational Banner -->
+      <footer class="motivational-banner anim-fade" style="--delay: 10">
+        <div class="banner-content">
+          <span class="banner-icon">{motivation.icon}</span>
+          <p class="banner-text">{motivation.text}</p>
+        </div>
+      </footer>
+    </div>
+  </main>
+
+  <!-- Cal-Heatmap -->
+  <link rel="stylesheet" href="https://unpkg.com/cal-heatmap/dist/cal-heatmap.css">
+  <script is:inline src="https://cdn.jsdelivr.net/npm/dayjs@1.11.10/dayjs.min.js"></script>
+  <script is:inline src="https://unpkg.com/@popperjs/core@2"></script>
+  <script is:inline src="https://unpkg.com/d3@7"></script>
+  <script is:inline src="https://unpkg.com/cal-heatmap/dist/cal-heatmap.min.js"></script>
+  <script is:inline src="https://unpkg.com/cal-heatmap/dist/plugins/Tooltip.min.js"></script>
+
+  <script is:inline define:vars={{ heatmapData }}>
+    document.addEventListener('DOMContentLoaded', () => {
+      try {
+        const cal = new CalHeatmap();
+        cal.paint({
+          itemSelector: "#cal-heatmap",
+          domain: {
+            type: "month",
+            gutter: 8,
+            label: { text: "MMM", position: "top", textAlign: "middle" },
+          },
+          subDomain: { 
+            type: "day", 
+            radius: 2, 
+            width: 14, 
+            height: 14, 
+            gutter: 4 
+          },
+          date: { 
+            start: new Date(2025, 0, 1),
+            min: new Date(2025, 0, 1),
+            max: new Date()
+          },
+          data: {
+            source: heatmapData,
+            type: "json",
+            x: "date",
+            y: "value",
+          },
+          scale: {
+            color: {
+              type: "threshold",
+              range: ["#1e1e2e", "#4c3da1", "#7c6af7", "#a89bff"],
+              domain: [1, 2, 3],
+            },
+          },
+        }, [
+          [
+            Tooltip,
+            {
+              text: (date, value, dayjsDate) => {
+                return (value ? value : "0") + " posts on " + (dayjsDate ? dayjsDate.format("LL") : new Date(date).toLocaleDateString());
+              },
+            },
+          ],
+        ]);
+      } catch (e) {
+        console.error("Cal-Heatmap error:", e);
+      }
+    });
+
+    // 2. Animate Count-up
+    const counters = document.querySelectorAll('.stat-value');
+    counters.forEach(counter => {
+      const target = +counter.getAttribute('data-target');
+      const duration = 1500;
+      const step = target / (duration / 16);
+      let current = 0;
+
+      const updateCounter = () => {
+        current += step;
+        if (current < target) {
+          counter.innerText = Math.floor(current).toLocaleString();
+          requestAnimationFrame(updateCounter);
+        } else {
+          counter.innerText = target.toLocaleString();
+        }
+      };
+      updateCounter();
+    });
+  </script>
+
+  <style>
+    .stats-page {
+      padding-top: var(--space-section);
+      background-color: var(--color-bg);
+      min-height: 100vh;
+    }
+
+    .stats-container {
+      max-width: var(--wide-width);
+      margin: 0 auto;
+      padding: 0 1.5rem 6rem;
+    }
+
+    .stats-header {
+      text-align: center;
+      margin-bottom: 4rem;
+    }
+
+    .stats-header h1 {
+      font-size: clamp(2.5rem, 6vw, 4rem);
+      margin-bottom: 1rem;
+    }
+
+    .stats-subtitle {
+      color: var(--color-text-secondary);
+      font-size: 1.1rem;
+    }
+
+    /* Summary Cards */
+    .summary-cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1.5rem;
+      margin-bottom: 4rem;
+    }
+
+    .stat-card {
+      background: var(--color-bg-card);
+      border: 1px solid var(--color-border);
+      padding: 2rem;
+      border-radius: 1rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      transition: transform var(--transition-base);
+    }
+
+    .stat-card:hover {
+      transform: translateY(-5px);
+      border-color: var(--color-accent);
+    }
+
+    .stat-value {
+      font-family: var(--font-display);
+      font-size: 2.5rem;
+      font-weight: 700;
+      color: var(--color-accent);
+      line-height: 1;
+      margin-bottom: 0.5rem;
+    }
+
+    .stat-label {
+      color: var(--color-text-muted);
+      font-family: var(--font-display);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      font-size: 0.8rem;
+      font-weight: 700;
+    }
+
+    /* Heatmap */
+    .heatmap-section {
+      background: var(--color-bg-card);
+      border: 1px solid var(--color-border);
+      padding: 2.5rem;
+      border-radius: 1rem;
+      margin-bottom: 3rem;
+    }
+
+    .section-title {
+      font-family: var(--font-display);
+      font-size: 1.25rem;
+      font-weight: 700;
+      margin-bottom: 2rem;
+      color: var(--color-text-primary);
+    }
+
+    .heatmap-wrapper {
+      overflow-x: auto;
+      padding-bottom: 1rem;
+    }
+
+    #cal-heatmap {
+      min-width: 800px;
+    }
+
+    /* Rows and Columns */
+    .stats-row {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 3rem;
+      margin-bottom: 3rem;
+    }
+
+    @media (min-width: 1024px) {
+      .stats-row {
+        grid-template-columns: 1fr 1fr;
+      }
+    }
+
+    .stats-col {
+      background: var(--color-bg-card);
+      border: 1px solid var(--color-border);
+      padding: 2rem;
+      border-radius: 1rem;
+    }
+
+    /* Streaks */
+    .streak-cards {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+    }
+
+    .streak-card {
+      background: rgba(255, 255, 255, 0.03);
+      padding: 1.5rem;
+      border-radius: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    .streak-icon {
+      font-size: 2rem;
+    }
+
+    .streak-info {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .streak-value {
+      font-family: var(--font-display);
+      font-size: 1.75rem;
+      font-weight: 700;
+      color: var(--color-text-primary);
+      line-height: 1.2;
+    }
+
+    .streak-label {
+      font-size: 0.8rem;
+      color: var(--color-text-muted);
+    }
+
+    /* Category Bars */
+    .category-bars {
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+    }
+
+    .bar-row {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .bar-info {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.9rem;
+    }
+
+    .bar-label {
+      font-family: var(--font-display);
+      font-weight: 700;
+      color: var(--color-text-secondary);
+    }
+
+    .bar-count {
+      color: var(--color-text-muted);
+    }
+
+    .bar-container {
+      height: 8px;
+      background: rgba(255, 255, 255, 0.05);
+      border-radius: 4px;
+      overflow: hidden;
+    }
+
+    .bar-fill {
+      height: 100%;
+      border-radius: 4px;
+      transition: width 1s ease-out;
+    }
+
+    /* Monthly Chart */
+    .monthly-chart {
+      display: flex;
+      align-items: flex-end;
+      justify-content: space-between;
+      height: 150px;
+      gap: 0.5rem;
+    }
+
+    .month-column {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.75rem;
+      height: 100%;
+    }
+
+    .column-wrapper {
+      flex: 1;
+      width: 100%;
+      display: flex;
+      align-items: flex-end;
+      background: rgba(255, 255, 255, 0.03);
+      border-radius: 4px;
+      overflow: hidden;
+    }
+
+    .column-fill {
+      width: 100%;
+      background: var(--color-accent);
+      opacity: 0.7;
+      border-radius: 2px;
+      transition: all var(--transition-base);
+      cursor: pointer;
+      position: relative;
+    }
+
+    .column-fill:hover {
+      opacity: 1;
+      background: var(--color-accent-bright);
+      transform: scaleX(1.1);
+    }
+
+    .month-label {
+      font-size: 0.7rem;
+      color: var(--color-text-muted);
+      text-transform: uppercase;
+      font-weight: 700;
+    }
+
+    /* Tooltip Hook */
+    [data-tooltip] {
+      position: relative;
+    }
+
+    [data-tooltip]::after {
+      content: attr(data-tooltip);
+      position: absolute;
+      bottom: 100%;
+      left: 50%;
+      transform: translateX(-50%) translateY(-8px);
+      background: #000;
+      color: #fff;
+      padding: 0.4rem 0.6rem;
+      border-radius: 4px;
+      font-size: 0.7rem;
+      white-space: nowrap;
+      opacity: 0;
+      pointer-events: none;
+      transition: all 0.2s ease;
+      z-index: 20;
+    }
+
+    [data-tooltip]:hover::after {
+      opacity: 1;
+      transform: translateX(-50%) translateY(-12px);
+    }
+
+    /* Tag List */
+    .tag-list {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .tag-rank-item {
+      display: flex;
+      align-items: center;
+      padding: 0.5rem 0;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    }
+
+    .tag-rank {
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      color: var(--color-text-muted);
+      width: 2.5rem;
+    }
+
+    .tag-name {
+      flex: 1;
+      font-family: var(--font-display);
+      font-weight: 700;
+      color: var(--color-text-primary);
+    }
+
+    .tag-count-pill {
+      background: var(--color-accent-glow);
+      color: var(--color-accent-bright);
+      padding: 0.2rem 0.6rem;
+      border-radius: 1rem;
+      font-size: 0.75rem;
+      font-weight: 700;
+      font-family: var(--font-mono);
+    }
+
+    /* Motivational Banner */
+    .motivational-banner {
+      background: linear-gradient(90deg, var(--color-bg-card), rgba(124, 106, 247, 0.05));
+      border: 1px solid var(--color-border);
+      padding: 2.5rem;
+      border-radius: 1.5rem;
+      text-align: center;
+    }
+
+    .banner-content {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    .banner-icon {
+      font-size: 3rem;
+    }
+
+    .banner-text {
+      font-family: var(--font-display);
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--color-text-primary);
+      max-width: 600px;
+    }
+
+    /* Animations */
+    .anim-fade {
+      opacity: 0;
+      transform: translateY(20px);
+      animation: fadeUp 0.8s ease forwards;
+      animation-delay: calc(var(--delay) * 0.1s);
+    }
+
+    @keyframes fadeUp {
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+  </style>
+</BaseLayout>


### PR DESCRIPTION
Closes #9

Implemented a comprehensive `/stats` page providing:
- Total posts, word counts, and category distribution.
- Interactive publishing heatmap using `cal-heatmap` (v4).
- Writing streak calculations (current and longest).
- Horizontal and vertical bar charts for category and monthly activity.
- Motivational banner based on posting consistency.

Verified with `npm run build` and visual confirmation via browser subagent. Added `Popper.js` and `dayjs` dependencies for correct heatmap rendering.