### PR TITLE
feat: update production domain to blogs.nishanthm.com (#11)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-PUBLIC_SITE_URL=https://yourdomain.com
+PUBLIC_SITE_URL=https://blogs.nishanthm.com
 PUBLIC_GISCUS_REPO=NishanthMuruganantham/nishanthm-blogs
 PUBLIC_GISCUS_REPO_ID=
 PUBLIC_GISCUS_CATEGORY=Announcements

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,7 +9,7 @@ import tailwind from '@astrojs/tailwind';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://nishanthm.dev',
+  site: 'https://blogs.nishanthm.com/',
 
   integrations: [
     mdx({

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -2,7 +2,7 @@
 
 export const SITE_TITLE = 'Nishanth Muruganantham';
 export const SITE_DESCRIPTION = 'Personal blog and portfolio of Nishanth Muruganantham';
-export const SITE_URL = 'https://nishanthm.dev';
+export const SITE_URL = 'https://blogs.nishanthm.com';
 export const SITE_AUTHOR = '@nishanthm';
 export const SITE_AUTHOR_FULL = 'Nishanth Muruganantham';
 


### PR DESCRIPTION
Closes #11

This PR updates the production domain from `nishanthm.dev` to `blogs.nishanthm.com` across the codebase and documentation. 

### Changes:
- **`astro.config.mjs`**: Updated `site` property for sitemap/RSS generation.
- **`src/consts.ts`**: Updated `SITE_URL` constant.
- **`SKILL.md`**: Fixed domain consistency in project instructions.
- **`.env.example`**: Updated domain hints.

**Assigned to:** NishanthMuruganantham
**Labels:** deployment, seo, documentation