### PR TITLE
feat: build design system and core components

### DIFF
--- a/src/components/ui/Button.astro
+++ b/src/components/ui/Button.astro
@@ -1,0 +1,50 @@
+---
+export interface Props {
+  variant?: "primary" | "secondary" | "ghost";
+  as?: "button" | "a";
+  href?: string;
+  disabled?: boolean;
+  class?: string;
+  [key: string]: any;
+}
+
+const {
+  variant = "ghost",
+  as: Component = "button",
+  href,
+  disabled = false,
+  class: className = "",
+  ...rest
+} = Astro.props;
+
+// Define base classes
+const baseClasses =
+  "inline-flex items-center gap-2 px-6 py-3 font-display font-bold text-[0.95rem] rounded-lg transition-all duration-250 disabled:opacity-50 disabled:cursor-not-allowed";
+
+// Define variant classes
+const variants = {
+  primary:
+    "bg-accent text-white hover:bg-accent-bright hover:shadow-[0_0_24px_var(--color-accent-glow),0_0_48px_var(--color-accent-08)] hover:-translate-y-[1px]",
+  secondary:
+    "bg-bg-elevated text-text-primary border border-border hover:border-accent hover:text-accent-bright hover:-translate-y-[1px]",
+  ghost:
+    "bg-transparent text-accent-bright border-[1.5px] border-border hover:border-accent hover:bg-accent-glow hover:text-accent-bright hover:-translate-y-[1px]",
+};
+
+// Add cursor-pointer only if not disabled
+const cursorClass = disabled ? "" : "cursor-pointer";
+
+const mergedClasses = `${baseClasses} ${cursorClass} ${variants[variant]} ${className}`;
+
+// If it's an 'a' tag but disabled, we might want to drop the href to prevent navigation
+const componentProps =
+  Component === "a" && !disabled ? { href, ...rest } : rest;
+---
+
+<Component
+  class={mergedClasses}
+  disabled={disabled && Component === "button"}
+  {...componentProps}
+>
+  <slot />
+</Component>


### PR DESCRIPTION
Closes #46

- Added base Button Astro component supporting primary, secondary, and ghost variants mapping to our CSS variables.
- Utilized Astro fallback props pattern mapping equivalent to kwargs default fallback.