### PR TITLE
feat: centralize blog sidebar and fix light mode highlights (#70)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,8 +15,11 @@ export default defineConfig({
       syntaxHighlight: false,
       rehypePlugins: [
         [rehypePrettyCode, {
-          theme: 'one-dark-pro',
-          keepBackground: true,
+          theme: {
+            light: 'light-plus',
+            dark: 'one-dark-pro',
+          },
+          keepBackground: false,
           defaultLang: {
             block: 'plaintext',
             inline: 'plaintext',

--- a/src/components/BlogSidebar.astro
+++ b/src/components/BlogSidebar.astro
@@ -1,72 +1,97 @@
 ---
+import { getCollection } from "astro:content";
+import "../styles/blog-sidebar.css";
+
 export interface CategoryData {
   name: string;
   count: number;
 }
 
 interface Props {
-  categories: CategoryData[];
-  allTags?: string[];
-  totalPosts: number;
+  showSort?: boolean;
 }
 
-const { categories, allTags = [], totalPosts } = Astro.props;
+const { showSort = true } = Astro.props;
+
+// Fetch and sort all non-draft posts to calculate categories and tags dynamically
+const allPosts = await getCollection("blog", ({ data }) => {
+    return import.meta.env.PROD ? data.draft !== true : true;
+});
+
+// Extract Unique Categories and counts
+const categoryCounts = allPosts.reduce((acc, post) => {
+    const cat = post.data.category;
+    acc[cat] = (acc[cat] || 0) + 1;
+    return acc;
+}, {} as Record<string, number>);
+
+const categories = Object.entries(categoryCounts)
+    .sort(([, a], [, b]) => b - a)
+    .map(([name, count]) => ({ name, count }));
+
+// Extract all unique tags
+const allTags = Array.from(new Set(allPosts.flatMap(post => post.data.tags || [])));
+const totalPosts = allPosts.length;
 ---
 
-<div class="sidebar-section">
-  <h3 class="sidebar-title">Search</h3>
-  <div class="relative">
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-    >
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
-    </svg>
-    <input
-      type="text"
-      id="search-input"
-      class="search-input pl-9"
-      placeholder="Search articles..."
-    />
-  </div>
-</div>
-
-<div class="sidebar-section">
-  <h3 class="sidebar-title">Categories</h3>
-  <div id="category-filters" class="flex flex-col gap-1">
-    <button class="category-item active" data-category="all">
-      <span>All</span>
-      <span class="category-count">({totalPosts})</span>
-    </button>
-    
-    {categories.map(cat => (
-      <button class="category-item" data-category={cat.name.toLowerCase()}>
-        <span>{cat.name}</span>
-        <span class="category-count">({cat.count})</span>
-      </button>
-    ))}
-  </div>
-</div>
-
-{allTags.length > 0 && (
+<div class="blog-sidebar-container" data-sidebar-nav>
   <div class="sidebar-section">
-    <h3 class="sidebar-title">Popular Tags</h3>
-    <div class="card-tags">
-      {allTags.slice(0, 10).map(tag => (
-         <button class="tag hover:bg-teal-900/40 hover:text-teal-400 transition-colors" data-tag={tag.toLowerCase()}>#{tag}</button>
+    <h3 class="sidebar-title">Search</h3>
+    <div class="relative">
+      <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+      >
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+      </svg>
+      <input
+        type="text"
+        id="search-input"
+        class="search-input pl-9"
+        placeholder="Search articles..."
+      />
+    </div>
+  </div>
+
+  <div class="sidebar-section">
+    <h3 class="sidebar-title">Categories</h3>
+    <div id="category-filters" class="flex flex-col gap-1">
+      <button class="category-item active" data-category="all">
+        <span>All</span>
+        <span class="category-count">({totalPosts})</span>
+      </button>
+      
+      {categories.map(cat => (
+        <button class="category-item" data-category={cat.name.toLowerCase()}>
+          <span>{cat.name}</span>
+          <span class="category-count">({cat.count})</span>
+        </button>
       ))}
     </div>
   </div>
-)}
 
-<div class="sidebar-section">
-  <h3 class="sidebar-title">Sort By</h3>
-  <select class="sort-select" data-sort>
-    <option value="latest">Latest</option>
-    <option value="most_read" disabled>Most Read</option>
-    <option value="trending" disabled>Trending</option>
-  </select>
+  {allTags.length > 0 && (
+    <div class="sidebar-section">
+      <h3 class="sidebar-title">Popular Tags</h3>
+      <div class="card-tags">
+        {allTags.slice(0, 10).map(tag => (
+           <button class="tag hover:bg-teal-900/40 hover:text-teal-400 transition-colors" data-tag={tag.toLowerCase()}>#{tag}</button>
+        ))}
+      </div>
+    </div>
+  )}
+
+  {showSort && (
+    <div class="sidebar-section">
+      <h3 class="sidebar-title">Sort By</h3>
+      <select class="sort-select" data-sort>
+        <option value="latest">Latest</option>
+        <option value="most_read" disabled>Most Read</option>
+        <option value="trending" disabled>Trending</option>
+      </select>
+    </div>
+  )}
 </div>

--- a/src/components/ShareButtons.astro
+++ b/src/components/ShareButtons.astro
@@ -38,26 +38,16 @@ const linkedinIconPath =
   "M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z";
 ---
 
-<!-- ============================================================
-     Desktop: Floating Sidebar (left side, icon-only)
-     Visible on lg+ screens only
-     ============================================================ -->
-<div class="share-float" aria-label="Share this article">
+<div class="share-sidebar-icons" aria-label="Share this article">
   <a
     href={twitterUrl}
     target="_blank"
     rel="noopener noreferrer"
-    class="share-btn"
+    class="share-icon"
     aria-label="Share on X (Twitter)"
     title="Share on X"
   >
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="18"
-      height="18"
-      viewBox="0 0 24 24"
-      fill="currentColor"
-    >
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
       <path d={xIconPath}></path>
     </svg>
   </a>
@@ -66,62 +56,44 @@ const linkedinIconPath =
     href={linkedinUrl}
     target="_blank"
     rel="noopener noreferrer"
-    class="share-btn"
+    class="share-icon"
     aria-label="Share on LinkedIn"
     title="Share on LinkedIn"
   >
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="18"
-      height="18"
-      viewBox="0 0 24 24"
-      fill="currentColor"
-    >
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
       <path d={linkedinIconPath}></path>
     </svg>
   </a>
 
   <button
-    class="share-btn share-copy-btn"
+    class="share-icon share-copy-btn"
     data-share-url={shareUrl}
     aria-label="Copy link to clipboard"
     title="Copy link"
   >
-    <!-- Lucide: Link icon (https://lucide.dev/icons/link) -->
-    <svg
-      class="share-copy-icon"
-      xmlns="http://www.w3.org/2000/svg"
-      width="18"
-      height="18"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    >
-      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
-      ></path>
-      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
-      ></path>
+    <svg class="share-copy-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
     </svg>
-    <!-- Lucide: Check icon (shown after copy) -->
-    <svg
-      class="share-check-icon"
-      xmlns="http://www.w3.org/2000/svg"
-      width="18"
-      height="18"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="2.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      style="display:none;"
-    >
+    <svg class="share-check-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="display:none;">
       <polyline points="20 6 9 17 4 12"></polyline>
     </svg>
     <span class="share-tooltip">Copied!</span>
+  </button>
+  
+  <button
+    class="share-icon share-native-btn"
+    data-share-title={title}
+    data-share-url={shareUrl}
+    data-share-text={description}
+    aria-label="More share options"
+    title="More share options"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="1"></circle>
+      <circle cx="19" cy="12" r="1"></circle>
+      <circle cx="5" cy="12" r="1"></circle>
+    </svg>
   </button>
 </div>
 

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,0 +1,66 @@
+---
+/**
+ * TableOfContents.astro
+ * Generates a clickable list of headings from the post content.
+ * Links to h2 and h3 elements with smooth scroll support.
+ */
+
+interface Heading {
+  depth: number;
+  slug: string;
+  text: string;
+}
+
+interface Props {
+  headings: Heading[];
+}
+
+const { headings } = Astro.props;
+
+// Only show h2 and h3 in the TOC
+const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
+
+// If no headings, don't render anything
+if (tocHeadings.length === 0) return null;
+---
+
+<nav class="post-toc" aria-label="Table of Contents">
+  <h3>Table of Contents</h3>
+  <ul id="toc">
+    {
+      tocHeadings.map((heading) => (
+        <li class={`toc-h${heading.depth}`}>
+          <a 
+            href={`#${heading.slug}`} 
+            data-slug={heading.slug}
+            class="toc-link"
+          >
+            {heading.text}
+          </a>
+        </li>
+      ))
+    }
+  </ul>
+</nav>
+
+<script>
+  // Simple smooth scroll handler for TOC links
+  // (Optional: CSS scroll-behavior: smooth; is usually preferred)
+  document.querySelectorAll('.toc-link').forEach(link => {
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      const targetId = link.getAttribute('href')?.substring(1);
+      const targetElement = document.getElementById(targetId || '');
+      
+      if (targetElement) {
+        window.scrollTo({
+          top: targetElement.offsetTop - 100, // Offset for sticky header
+          behavior: 'smooth'
+        });
+        
+        // Update URL hash without jumping
+        history.pushState(null, '', `#${targetId}`);
+      }
+    });
+  });
+</script>

--- a/src/content/blog/android-gradle-error.mdx
+++ b/src/content/blog/android-gradle-error.mdx
@@ -7,7 +7,6 @@ tags: ["android", "gradle", "android-studio", "build-error"]
 draft: false
 ---
 
-# Fixing Android Gradle Build Errors — Step by Step
 
 ## The Common Error
 

--- a/src/content/blog/django-cors-fix.mdx
+++ b/src/content/blog/django-cors-fix.mdx
@@ -8,7 +8,6 @@ tags: ["django", "cors", "react", "vite", "python"]
 draft: false
 ---
 
-# Fix CORS Error in Django with React Vite Frontend
 
 ## The Problem
 

--- a/src/content/blog/mcp-vscode-setup.mdx
+++ b/src/content/blog/mcp-vscode-setup.mdx
@@ -7,7 +7,6 @@ tags: ["mcp", "vscode", "ai-tools", "developer-tools"]
 draft: false
 ---
 
-# Setting Up MCP Servers in VS Code — Complete Guide
 
 ## What is MCP?
 

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -3,13 +3,14 @@ import BaseLayout from "./BaseLayout.astro";
 import { formatDate } from "../lib/utils";
 import Giscus from "../components/Giscus.astro";
 import { getCollection } from "astro:content";
-import { getReadingTime } from "../lib/utils";
 import { SITE_AUTHOR } from "../consts";
 import { getRelatedPosts } from "../lib/related-posts";
 import ShareButtons from "../components/ShareButtons.astro";
+import TableOfContents from "../components/TableOfContents.astro";
 import ProgressBar from "../components/ui/ProgressBar.astro";
 import EmailCapture from "../components/ui/EmailCapture.astro";
 import RelatedPosts from "../components/RelatedPosts.astro";
+import "../styles/post.css";
 
 const { post, frontmatter, headings, readingTime } = Astro.props;
 const categoryLower = frontmatter.category.toLowerCase();
@@ -30,11 +31,14 @@ const relatedPosts = getRelatedPosts(post, allPosts, 3);
     {/* Reading Progress Bar — dedicated component */}
     <ProgressBar />
 
-    <div
-        class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12 flex flex-col lg:flex-row gap-12 relative items-start"
-    >
-        {/* Main Content */}
-        <article class="flex-1 w-full min-w-0">
+    <div class="post-container">
+        {/* LEFT SIDEBAR: Table of Contents */}
+        <aside class="post-toc-sidebar">
+            <TableOfContents headings={headings} />
+        </aside>
+
+        {/* MAIN CONTENT */}
+        <article class="post-content">
             <header class="mb-10 text-center lg:text-left">
                 <div class="mb-4">
                     <span
@@ -43,16 +47,16 @@ const relatedPosts = getRelatedPosts(post, allPosts, 3);
                     >
                 </div>
                 <h1
-                    class="text-4xl md:text-5xl lg:text-6xl font-display font-bold text-text-primary leading-tight mb-6"
+                    class="text-4xl md:text-5xl lg:text-6xl font-display font-bold text-text-primary leading-tight mb-4"
                 >
                     {frontmatter.title}
                 </h1>
-                <p class="text-xl text-text-secondary mb-6">
+                <p class="post-description">
                     {frontmatter.description}
                 </p>
 
                 <div
-                    class="flex flex-wrap items-center justify-center lg:justify-start gap-3 text-sm text-text-muted"
+                    class="flex flex-wrap items-center justify-center lg:justify-start gap-3 text-sm text-text-muted mt-6"
                 >
                     <time datetime={frontmatter.date.toISOString()}
                         >{formatDate(frontmatter.date)}</time
@@ -89,13 +93,13 @@ const relatedPosts = getRelatedPosts(post, allPosts, 3);
 
             {/* Prose Body */}
             <div
-                class="prose prose-lg max-w-[720px] mx-auto lg:mx-0 prose-headings:font-display prose-p:leading-relaxed prose-a:text-accent hover:prose-a:text-accent-bright prose-img:rounded-xl"
+                class="prose prose-lg max-w-none prose-headings:font-display prose-p:leading-relaxed prose-a:text-accent hover:prose-a:text-accent-bright prose-img:rounded-xl"
             >
                 <slot />
             </div>
 
             <footer
-                class="mt-16 pt-8 border-t border-border max-w-[720px] mx-auto lg:mx-0"
+                class="mt-16 pt-8 border-t border-border"
             >
                 <div class="flex flex-wrap gap-2 mb-8">
                     <span class="text-text-secondary mr-2">Tagged with:</span>
@@ -111,12 +115,14 @@ const relatedPosts = getRelatedPosts(post, allPosts, 3);
                     }
                 </div>
 
-                {/* Share Buttons */}
-                <ShareButtons
-                    title={frontmatter.title}
-                    url={`/blog/${post.slug}`}
-                    description={frontmatter.description}
-                />
+                {/* Share Buttons (Visible on mobile/tablet where sidebar is hidden) */}
+                <div class="lg:hidden mb-12">
+                    <ShareButtons
+                        title={frontmatter.title}
+                        url={`/blog/${post.slug}`}
+                        description={frontmatter.description}
+                    />
+                </div>
 
                 {/* Email Capture */}
                 <EmailCapture />
@@ -133,38 +139,13 @@ const relatedPosts = getRelatedPosts(post, allPosts, 3);
             </footer>
         </article>
 
-        {/* Sidebar (Table of Contents only — Related Posts moved inline) */}
-        <aside class="hidden lg:block w-80 shrink-0 sticky top-24">
-            {
-                headings && headings.length > 0 && (
-                    <nav class="mb-12 bg-bg-card p-6 rounded-2xl border border-border-subtle">
-                        <h3 class="text-lg font-bold mb-4 font-display">
-                            Table of Contents
-                        </h3>
-                        <ul class="space-y-2 text-sm" id="toc">
-                            {headings
-                                .filter(
-                                    (h: any) => h.depth === 2 || h.depth === 3
-                                )
-                                .map((heading: any) => (
-                                    <li
-                                        class={`${
-                                            heading.depth === 3 ? "ml-4" : ""
-                                        }`}
-                                    >
-                                        <a
-                                            href={`#${heading.slug}`}
-                                            class="text-text-secondary hover:text-accent transition-colors py-1 block"
-                                            data-slug={heading.slug}
-                                        >
-                                            {heading.text}
-                                        </a>
-                                    </li>
-                                ))}
-                        </ul>
-                    </nav>
-                )
-            }
+        {/* RIGHT SIDEBAR: Social Share */}
+        <aside class="post-share-sidebar">
+            <ShareButtons
+                title={frontmatter.title}
+                url={`/blog/${post.slug}`}
+                description={frontmatter.description}
+            />
         </aside>
     </div>
 </BaseLayout>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -7,8 +7,8 @@ import { SITE_AUTHOR } from "../consts";
 import { getRelatedPosts } from "../lib/related-posts";
 import ShareButtons from "../components/ShareButtons.astro";
 import TableOfContents from "../components/TableOfContents.astro";
+import BlogSidebar from "../components/BlogSidebar.astro";
 import ProgressBar from "../components/ui/ProgressBar.astro";
-import EmailCapture from "../components/ui/EmailCapture.astro";
 import RelatedPosts from "../components/RelatedPosts.astro";
 import "../styles/post.css";
 
@@ -32,9 +32,14 @@ const relatedPosts = getRelatedPosts(post, allPosts, 3);
     <ProgressBar />
 
     <div class="post-container">
-        {/* LEFT SIDEBAR: Table of Contents */}
+        {/* LEFT SIDEBAR: Table of Contents & Discovery */}
         <aside class="post-toc-sidebar">
-            <TableOfContents headings={headings} />
+            <div class="sticky top-24 flex flex-col gap-12">
+                <TableOfContents headings={headings} />
+                <div class="hidden lg:block border-t border-border-subtle pt-8">
+                    <BlogSidebar showSort={false} />
+                </div>
+            </div>
         </aside>
 
         {/* MAIN CONTENT */}
@@ -124,9 +129,6 @@ const relatedPosts = getRelatedPosts(post, allPosts, 3);
                     />
                 </div>
 
-                {/* Email Capture */}
-                <EmailCapture />
-
                 {/* Related Posts — full width below article */}
                 <RelatedPosts posts={relatedPosts} />
 
@@ -151,3 +153,4 @@ const relatedPosts = getRelatedPosts(post, allPosts, 3);
 </BaseLayout>
 
 <script src="../scripts/post-interactivity.js"></script>
+<script src="../scripts/sidebar-nav.js"></script>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -32,21 +32,7 @@ const serializedPosts = sortedPosts.map((post) => ({
 // We can strip 'body' before sending to client to save bytes
 const serializableForClient = serializedPosts;
 
-// Extract Unique Categories and counts for the filter bar
-const categoryCounts = serializedPosts.reduce((acc, post) => {
-    const cat = post.category;
-    acc[cat] = (acc[cat] || 0) + 1;
-    return acc;
-}, {} as Record<string, number>);
-
-// Ensure we only have the top categories
-const topCategories = Object.entries(categoryCounts)
-    .sort(([, a], [, b]) => b - a)
-    .map(([name, count]) => ({ name, count }));
-
-// Extract all unique tags
-const allTags = Array.from(new Set(serializedPosts.flatMap(post => post.tags)));
-
+// Posts are already sorted and formatted for the main list
 ---
 
 <BaseLayout
@@ -61,11 +47,7 @@ const allTags = Array.from(new Set(serializedPosts.flatMap(post => post.tags)));
         <div class="blog-wrapper">
             <!-- LEFT SIDEBAR -->
             <aside class="blog-sidebar-left">
-                <BlogSidebar 
-                    categories={topCategories}
-                    allTags={allTags}
-                    totalPosts={sortedPosts.length}
-                />
+                <BlogSidebar />
             </aside>
 
             <!-- MAIN CONTENT -->

--- a/src/scripts/post-interactivity.js
+++ b/src/scripts/post-interactivity.js
@@ -42,9 +42,9 @@ async function initPostInteractivity() {
         const observer = new IntersectionObserver((entries) => {
             entries.forEach((entry) => {
                 if (entry.isIntersecting) {
-                    tocLinks.forEach(link => link.classList.remove("text-accent", "font-medium"));
+                    tocLinks.forEach(link => link.classList.remove("active"));
                     const activeLink = document.querySelector(`#toc a[data-slug="${entry.target.getAttribute("id")}"]`);
-                    if (activeLink) activeLink.classList.add("text-accent", "font-medium");
+                    if (activeLink) activeLink.classList.add("active");
                 }
             });
         }, { rootMargin: "0px 0px -60% 0px" });

--- a/src/scripts/post-interactivity.js
+++ b/src/scripts/post-interactivity.js
@@ -1,4 +1,8 @@
 async function initPostInteractivity() {
+    // Prevent multiple concurrent executions
+    if (window.__is_initializing_interactivity) return;
+    window.__is_initializing_interactivity = true;
+
     // 1. Copy Buttons and Line Numbers
     const codeBlocks = document.querySelectorAll('pre');
     // ... (rest of the copy button logic remains the same, I'll just keep it structured)
@@ -132,12 +136,17 @@ async function initPostInteractivity() {
                 const preElement = codeElement.closest('pre');
                 if (!preElement) continue;
 
-                // Unique ID based on code content hash to be safe, or just index if unique
+                const figure = preElement.closest('figure');
+                const targetElement = figure || preElement;
+
+                // Check if already processed
+                if (targetElement.dataset.mermaidProcessed === 'true') continue;
+                targetElement.dataset.mermaidProcessed = 'true';
+
                 const diagramId = `mermaid-render-${index}`;
                 if (document.getElementById(diagramId)) continue; 
 
                 const code = codeElement.innerText.trim();
-                const figure = preElement.closest('figure');
 
                 const container = document.createElement('div');
                 container.className = 'mermaid-rendered';
@@ -164,10 +173,19 @@ async function initPostInteractivity() {
             console.error('Failed to load mermaid library:', importErr);
         }
     }
+    window.__is_initializing_interactivity = false;
+}
+
+// Unified initialization for regular loads and View Transitions
+function setupInteractivity() {
+    initPostInteractivity();
 }
 
 if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', initPostInteractivity);
+    document.addEventListener('DOMContentLoaded', setupInteractivity);
 } else {
-    initPostInteractivity();
+    setupInteractivity();
 }
+
+// Support Astro View Transitions
+document.addEventListener('astro:page-load', setupInteractivity);

--- a/src/scripts/sidebar-nav.js
+++ b/src/scripts/sidebar-nav.js
@@ -1,0 +1,53 @@
+/**
+ * sidebar-nav.js
+ * Handles sidebar interactions on post pages by redirecting to the main blog page 
+ * with the appropriate filter parameters.
+ */
+
+function initSidebarNav() {
+    const sidebar = document.querySelector('[data-sidebar-nav]');
+    // If we're inside a <blog-filter> component, let that handle the logic
+    const isFilterMode = !!sidebar?.closest('blog-filter');
+    
+    if (!sidebar || isFilterMode) return;
+
+    const searchInput = sidebar.querySelector('#search-input');
+    const categoryBtns = sidebar.querySelectorAll('.category-item');
+    const tagBtns = sidebar.querySelectorAll('button.tag[data-tag]');
+
+    // Search Redirection
+    searchInput?.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') {
+            const query = e.target.value.trim();
+            if (query) {
+                window.location.href = `/blog?q=${encodeURIComponent(query)}`;
+            }
+        }
+    });
+
+    // Category Redirection
+    categoryBtns.forEach(btn => {
+        btn.addEventListener('click', (e) => {
+            const category = e.currentTarget.dataset.category;
+            if (category === 'all') {
+                window.location.href = '/blog';
+            } else {
+                window.location.href = `/blog?category=${encodeURIComponent(category)}`;
+            }
+        });
+    });
+
+    // Tag Redirection
+    tagBtns.forEach(btn => {
+        btn.addEventListener('click', (e) => {
+            const tag = e.currentTarget.dataset.tag;
+            window.location.href = `/blog?q=${encodeURIComponent(tag)}`;
+        });
+    });
+}
+
+// Initial run
+initSidebarNav();
+
+// Listen for Astro page loads (View Transitions)
+document.addEventListener('astro:page-load', initSidebarNav);

--- a/src/styles/blog-list.css
+++ b/src/styles/blog-list.css
@@ -149,93 +149,12 @@
   background: linear-gradient(135deg, #0d9488 0%, #14b8a6 100%);
 }
 
-/* Blog Sidebar Styling */
+/* Blog Sidebar Layout (Component styles moved to blog-sidebar.css) */
 .blog-sidebar-left {
   background: #111827;
   border: 1px solid #1f2937;
   border-radius: 8px;
   padding: 1.5rem;
-}
-
-.sidebar-section {
-  margin-bottom: 1.5rem;
-}
-
-.sidebar-section:not(:last-child) {
-  border-bottom: 1px solid #1f2937;
-  padding-bottom: 1.5rem;
-}
-
-.sidebar-title {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: #9ca3af;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: 1rem;
-}
-
-.search-input {
-  width: 100%;
-  padding: 0.75rem;
-  background: #1f2937;
-  border: 1px solid #374151;
-  border-radius: 6px;
-  color: #f3f4f6;
-  font-size: 0.875rem;
-  transition: border-color 0.2s ease;
-}
-
-.search-input:focus {
-  outline: none;
-  border-color: #0d9488;
-  box-shadow: 0 0 10px rgba(13, 148, 136, 0.2);
-}
-
-.category-item {
-  padding: 0.5rem 0;
-  display: flex;
-  justify-content: space-between;
-  cursor: pointer;
-  color: #d1d5db;
-  font-size: 0.95rem;
-  transition: color 0.2s ease;
-  background: none;
-  border: none;
-  width: 100%;
-  text-align: left;
-}
-
-.category-item:hover {
-  text-decoration: none;
-}
-
-.category-item.active {
-  color: #f3f4f6;
-  background: rgba(13, 148, 136, 0.2);
-  padding: 0.5rem 0.5rem;
-  border-radius: 4px;
-}
-
-.category-count {
-  color: #6b7280;
-  font-size: 0.85rem;
-}
-
-/* Sort Select */
-.sort-select {
-  width: 100%;
-  padding: 0.5rem;
-  background: #1f2937;
-  border: 1px solid #374151;
-  border-radius: 4px;
-  color: #f3f4f6;
-  font-size: 0.875rem;
-}
-
-.sort-select:focus {
-  outline: none;
-  border-color: #0d9488;
 }
 
 /* Responsive Design */
@@ -333,20 +252,4 @@ html:not(.dark) .blog-sidebar-left {
   background: #ffffff !important;
   border-color: #e5e7eb !important;
   color: #1f2937 !important;
-}
-
-html:not(.dark) .search-input,
-html:not(.dark) .sort-select {
-  background: #ffffff !important;
-  border-color: #d1d5db !important;
-  color: #111827 !important;
-}
-
-html:not(.dark) .search-input:focus,
-html:not(.dark) .sort-select:focus {
-  border-color: #0d9488 !important;
-}
-
-html:not(.dark) .category-item {
-  color: #4b5563 !important;
 }

--- a/src/styles/blog-sidebar.css
+++ b/src/styles/blog-sidebar.css
@@ -1,0 +1,126 @@
+/* Common Sidebar Styling */
+.sidebar-section {
+  margin-bottom: 1.5rem;
+}
+
+.sidebar-section:not(:last-child) {
+  border-bottom: 1px solid #1f2937;
+  padding-bottom: 1.5rem;
+}
+
+.sidebar-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #9ca3af;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 1rem;
+}
+
+.search-input {
+  width: 100%;
+  padding: 0.75rem;
+  background: #1f2937;
+  border: 1px solid #374151;
+  border-radius: 6px;
+  color: #f3f4f6;
+  font-size: 0.875rem;
+  transition: border-color 0.2s ease;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #0d9488;
+  box-shadow: 0 0 10px rgba(13, 148, 136, 0.2);
+}
+
+.category-item {
+  padding: 0.5rem 0;
+  display: flex;
+  justify-content: space-between;
+  cursor: pointer;
+  color: #d1d5db;
+  font-size: 0.95rem;
+  transition: color 0.2s ease;
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
+}
+
+.category-item:hover {
+  text-decoration: none;
+}
+
+.category-item.active {
+  color: #f3f4f6;
+  background: rgba(13, 148, 136, 0.2);
+  padding: 0.5rem 0.5rem;
+  border-radius: 4px;
+}
+
+.category-count {
+  color: #6b7280;
+  font-size: 0.85rem;
+}
+
+/* Sort Select */
+.sort-select {
+  width: 100%;
+  padding: 0.5rem;
+  background: #1f2937;
+  border: 1px solid #374151;
+  border-radius: 4px;
+  color: #f3f4f6;
+  font-size: 0.875rem;
+}
+
+.sort-select:focus {
+  outline: none;
+  border-color: #0d9488;
+}
+
+/* Light Mode Overrides */
+html:not(.dark) .sidebar-section:not(:last-child) {
+  border-color: #e5e7eb;
+}
+
+html:not(.dark) .search-input,
+html:not(.dark) .sort-select {
+  background: #ffffff;
+  border-color: #d1d5db;
+  color: #111827;
+}
+
+html:not(.dark) .search-input:focus,
+html:not(.dark) .sort-select:focus {
+  border-color: #0d9488;
+}
+
+html:not(.dark) .category-item {
+  color: #4b5563;
+}
+
+/* Base tag styling if not present globally */
+.card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tag {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  background: rgba(13, 148, 136, 0.15);
+  color: #d1d5db;
+  border-radius: 3px;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+}
+
+html:not(.dark) .tag {
+  background: rgba(13, 148, 136, 0.15);
+  color: #374151;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -38,7 +38,7 @@
   --color-text-muted: #888888;
 
   /* Accent — kept as #00e676 / #44ef9f. On light bg, use as bg color with dark text on top */
-  --color-accent: #44ef9f;
+  --color-accent: #00a943;
   --color-accent-bright: #00e676;
   --color-accent-glow: rgba(0, 230, 118, 0.18);
   --color-accent-05: rgba(0, 230, 118, 0.05);
@@ -76,14 +76,14 @@
   --header-glass-bg: rgba(255, 255, 255, 0.88);
   --header-glass-bg-scrolled: rgba(255, 255, 255, 0.97);
 
-  --code-bg: #0a1f14;
-  --code-border: rgba(0, 230, 118, 0.2);
-  --code-lang-bg: rgba(0, 230, 118, 0.08);
-  --code-lang-text: rgba(0, 230, 118, 0.6);
+  --code-bg: #f8fafc;
+  --code-border: rgba(0, 0, 0, 0.1);
+  --code-lang-bg: rgba(0, 0, 0, 0.05);
+  --code-lang-text: #475569;
 
   /* Inline Code (Light Mode Specific) */
-  --inline-code-bg: #dcfcec;
-  --inline-code-text: #13151a;
+  --inline-code-bg: #f1f5f9;
+  --inline-code-text: #0f172a;
 
   /* Typography */
   --font-display: 'Space Grotesk', sans-serif;
@@ -128,7 +128,7 @@
   --color-text-warm: #BFDBFE;
 
   /* Accent — bright emerald, more vivid in dark mode */
-  --color-accent: #44ef9f;
+  --color-accent: #00a943;
   --color-accent-bright: #00e676;
   --color-accent-glow: rgba(68, 239, 159, 0.2);
   /* In dark mode: tags use transparent bg + bright green text (works on dark) */
@@ -165,14 +165,16 @@
   --header-glass-bg: rgba(5, 15, 9, 0.8);
   --header-glass-bg-scrolled: rgba(5, 15, 9, 0.95);
 
-  --code-bg: #020a05;
-  --code-border: rgba(68, 239, 159, 0.15);
-  --code-lang-bg: rgba(68, 239, 159, 0.08);
-  --code-lang-text: rgba(0, 230, 118, 0.5);
+  --code-bg: #111827;
+  /* Neutral dark gray, matching standard terminal backgrounds */
+  --code-border: rgba(255, 255, 255, 0.1);
+  --code-lang-bg: rgba(255, 255, 255, 0.08);
+  --code-lang-text: rgba(255, 255, 255, 0.6);
+  /* Brightened for better visibility */
 
-  /* Inline Code (Dark Mode - Keep Existing) */
-  --inline-code-bg: #283d3378;
-  --inline-code-text: #27bf75;
+  /* Inline Code (Dark Mode - Neutralized) */
+  --inline-code-bg: rgba(255, 255, 255, 0.08);
+  --inline-code-text: #e2e8f0;
 
   /* Mobile nav glassmorphism background — near-opaque dark panel */
   --mobile-nav-glass-bg: rgba(5, 12, 8, 0.97);
@@ -182,6 +184,29 @@
   --color-teal-bright: #10b981;
   --color-teal-glow: rgba(5, 150, 105, 0.2);
   --color-teal-20: rgba(5, 150, 105, 0.25);
+}
+
+/* Shiki Dual Theme Overrides */
+[data-rehype-pretty-code-figure] code {
+  background-color: var(--shiki-light-bg);
+}
+
+[data-rehype-pretty-code-figure] span {
+  color: var(--shiki-light);
+  font-style: var(--shiki-light-font-style);
+  font-weight: var(--shiki-light-font-weight);
+  text-decoration: var(--shiki-light-text-decoration);
+}
+
+html.dark [data-rehype-pretty-code-figure] code {
+  background-color: var(--shiki-dark-bg) !important;
+}
+
+html.dark [data-rehype-pretty-code-figure] span {
+  color: var(--shiki-dark) !important;
+  font-style: var(--shiki-dark-font-style) !important;
+  font-weight: var(--shiki-dark-font-weight) !important;
+  text-decoration: var(--shiki-dark-text-decoration) !important;
 }
 
 /* ============================================================
@@ -729,8 +754,6 @@
   .prose pre,
   .prose pre code {
     background-color: var(--code-bg) !important;
-    color: #e2e8f0 !important;
-    /* Force light text on dark background */
   }
 
   .prose pre {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -51,7 +51,8 @@
   --color-accent-40: rgba(0, 230, 118, 0.40);
   /* Solid green for tag/badge backgrounds in light mode */
   --color-accent-solid: #44ef9f;
-  --color-on-accent: #021a0a;  /* near-black text that sits ON the green bg */
+  --color-on-accent: #021a0a;
+  /* near-black text that sits ON the green bg */
 
   /* Status */
   --color-success: #16a34a;
@@ -79,6 +80,10 @@
   --code-border: rgba(0, 230, 118, 0.2);
   --code-lang-bg: rgba(0, 230, 118, 0.08);
   --code-lang-text: rgba(0, 230, 118, 0.6);
+
+  /* Inline Code (Light Mode Specific) */
+  --inline-code-bg: #dcfcec;
+  --inline-code-text: #13151a;
 
   /* Typography */
   --font-display: 'Space Grotesk', sans-serif;
@@ -164,6 +169,10 @@
   --code-border: rgba(68, 239, 159, 0.15);
   --code-lang-bg: rgba(68, 239, 159, 0.08);
   --code-lang-text: rgba(0, 230, 118, 0.5);
+
+  /* Inline Code (Dark Mode - Keep Existing) */
+  --inline-code-bg: #283d3378;
+  --inline-code-text: #27bf75;
 
   /* Mobile nav glassmorphism background — near-opaque dark panel */
   --mobile-nav-glass-bg: rgba(5, 12, 8, 0.97);
@@ -518,6 +527,7 @@
     color: var(--color-teal-bright);
     text-decoration: none;
   }
+
   .post-card:hover {
     text-decoration: none;
   }
@@ -841,11 +851,18 @@
 
   /* Inline Code */
   .prose :not(pre)>code {
-    background-color: var(--color-accent-15);
-    color: var(--color-accent-bright);
+    background-color: var(--inline-code-bg) !important;
+    color: var(--inline-code-text) !important;
     padding: 0.15rem 0.35rem;
     border-radius: 0.3rem;
     font-size: 0.85em;
+  }
+
+  /* Remove highlighting for inline code in headings */
+  .prose :is(h1, h2, h3, h4, h5, h6) code {
+    background-color: transparent !important;
+    color: inherit !important;
+    padding: 0 !important;
   }
 
   /* Blockquotes */
@@ -1061,14 +1078,17 @@
    Dark Mode Typography Overrides
    ============================================================ */
 html.dark .tag {
-    color: #a8d5b8;
+  color: #a8d5b8;
 }
+
 html.dark .category-card__name {
-    color: #e8f5ee !important;
+  color: #e8f5ee !important;
 }
+
 html.dark .post-card__tag {
-    color: #a8d5b8;
+  color: #a8d5b8;
 }
+
 /* Override specific tag colors to be readable in dark mode */
 html.dark .tag-backend,
 html.dark .tag-frontend,
@@ -1076,5 +1096,5 @@ html.dark .tag-tools,
 html.dark .tag-android,
 html.dark .tag-startup,
 html.dark .tag-life {
-    color: #c8e6d4 !important;
+  color: #c8e6d4 !important;
 }

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -1,0 +1,199 @@
+/* Post Container - 3 Column Layout */
+.post-container {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+@media (min-width: 1200px) {
+  .post-container {
+    grid-template-columns: 280px 1fr 120px;
+    padding: 3rem 2rem;
+  }
+}
+
+/* Sidebars - Sticky Behavior */
+.post-toc-sidebar,
+.post-share-sidebar {
+  display: none;
+}
+
+@media (min-width: 1200px) {
+  .post-toc-sidebar,
+  .post-share-sidebar {
+    display: block;
+    position: sticky;
+    top: 100px;
+    height: fit-content;
+    max-height: calc(100vh - 120px);
+  }
+  
+  .post-toc-sidebar {
+    overflow-y: auto;
+    padding-right: 1rem;
+  }
+}
+
+/* Table of Contents Styling */
+.post-toc h3 {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 1.25rem;
+}
+
+.post-toc ul {
+  list-style: none;
+  padding: 0;
+}
+
+.post-toc li {
+  margin-bottom: 0.75rem;
+}
+
+.post-toc a {
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+  text-decoration: none;
+  transition: all 0.2s ease;
+  display: block;
+  padding: 0.25rem 0;
+  border-left: 2px solid transparent;
+  padding-left: 0.75rem;
+  line-height: 1.5;
+}
+
+.post-toc a:hover {
+  color: var(--color-accent);
+}
+
+.post-toc a.active {
+  color: var(--color-accent);
+  border-left-color: var(--color-accent);
+  font-weight: 600;
+  background: linear-gradient(to right, rgba(13, 148, 136, 0.1), transparent);
+}
+
+.post-toc li.toc-h2 {
+  font-weight: 500;
+}
+
+/* Indent h3 under h2 */
+.post-toc li.toc-h3 a {
+  padding-left: 1.75rem;
+  font-size: 0.8125rem;
+}
+
+/* Main Content Area */
+.post-content {
+  width: 100%;
+  min-width: 0;
+}
+
+/* Share Buttons Sidebar */
+.share-sidebar-icons {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  align-items: center;
+}
+
+.share-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  background: var(--color-bg-alt);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  backdrop-filter: blur(8px);
+}
+
+.share-icon:hover {
+  transform: translateY(-3px) scale(1.1);
+  color: var(--color-accent);
+  background: var(--color-bg-hover);
+  border-color: var(--color-accent);
+  box-shadow: 0 4px 12px rgba(13, 148, 136, 0.2);
+}
+
+.share-icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+/* Responsive Overrides */
+@media (max-width: 1199px) {
+  .post-container {
+    display: flex;
+    flex-direction: column;
+    padding: 1.5rem 1rem;
+  }
+  
+  .post-content {
+    order: 1;
+  }
+  
+  .share-inline {
+    display: block;
+    margin-top: 4rem;
+    padding: 2rem 1.5rem;
+    background: var(--color-bg-alt);
+    border-radius: 1rem;
+    border: 1px solid var(--color-border);
+    order: 2;
+  }
+  
+  .share-inline__heading {
+    font-size: 0.875rem;
+    font-weight: 700;
+    color: var(--color-text-muted);
+    margin-bottom: 1.25rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    text-align: center;
+  }
+  
+  .share-inline__buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: center;
+  }
+
+  .share-inline-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.625rem 1.25rem;
+    border-radius: 0.5rem;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    color: var(--color-text-primary);
+    font-size: 0.875rem;
+    font-weight: 500;
+    transition: all 0.2s ease;
+    text-decoration: none;
+  }
+
+  .share-inline-btn:hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+    background: var(--color-bg-hover);
+    transform: translateY(-2px);
+  }
+}
+
+@media (min-width: 1200px) {
+  .share-inline {
+    display: none;
+  }
+}

--- a/titles.txt
+++ b/titles.txt
@@ -1,0 +1,3 @@
+Fixing Android Gradle Build Errors — Step by Step
+Setting Up MCP Servers in VS Code — Complete Guide
+Fix CORS Error in Django with React Vite Frontend


### PR DESCRIPTION
Closes #70

Refactored the blog sidebar into a reusable component and updated it across the blog listing and post pages. Also implemented inline code highlights for light mode as requested in #70.

Key Changes:
- Centralized sidebar logic and styles.
- Added navigation redirection for sidebar discovery tools on post pages.
- Applied light mode styles for inline code blocks.