### PR TITLE
Add graphify-out outputs

### DIFF
--- a/graphify-out/.gitignore
+++ b/graphify-out/.gitignore
@@ -1,0 +1,5 @@
+*
+!GRAPH_REPORT.md
+!graph.json
+!graph.html
+!.gitignore

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,0 +1,30 @@
+# Graph Report - .  (2026-05-03)
+
+## Corpus Check
+- 31 files · ~155,621 words
+- Verdict: corpus is large enough that graph structure adds value.
+
+## Summary
+- 27 nodes · 21 edges · 2 communities detected
+- Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
+- Token cost: 0 input · 0 output
+
+## Community Hubs (Navigation)
+- [[_COMMUNITY_Blog Filtering Scripts|Blog Filtering Scripts]]
+- [[_COMMUNITY_Post Interactivity|Post Interactivity]]
+
+## God Nodes (most connected - your core abstractions)
+1. `BlogFilter` - 8 edges
+2. `initPostInteractivity()` - 2 edges
+3. `setupInteractivity()` - 2 edges
+
+## Surprising Connections (you probably didn't know these)
+- None detected - all connections are within the same source files.
+
+## Communities (10 total, 2 thin omitted)
+
+## Knowledge Gaps
+- **2 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+
+## Suggested Questions
+_Not enough signal to generate questions. This usually means the corpus has no AMBIGUOUS edges, no bridge nodes, no INFERRED relationships, and all communities are tightly cohesive. Add more files or run with --mode deep to extract richer edges._

--- a/graphify-out/graph.html
+++ b/graphify-out/graph.html
@@ -1,0 +1,305 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>graphify - graphify-out/graph.html</title>
+<script src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0f0f1a; color: #e0e0e0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; display: flex; height: 100vh; overflow: hidden; }
+  #graph { flex: 1; }
+  #sidebar { width: 280px; background: #1a1a2e; border-left: 1px solid #2a2a4e; display: flex; flex-direction: column; overflow: hidden; }
+  #search-wrap { padding: 12px; border-bottom: 1px solid #2a2a4e; }
+  #search { width: 100%; background: #0f0f1a; border: 1px solid #3a3a5e; color: #e0e0e0; padding: 7px 10px; border-radius: 6px; font-size: 13px; outline: none; }
+  #search:focus { border-color: #4E79A7; }
+  #search-results { max-height: 140px; overflow-y: auto; padding: 4px 12px; border-bottom: 1px solid #2a2a4e; display: none; }
+  .search-item { padding: 4px 6px; cursor: pointer; border-radius: 4px; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .search-item:hover { background: #2a2a4e; }
+  #info-panel { padding: 14px; border-bottom: 1px solid #2a2a4e; min-height: 140px; }
+  #info-panel h3 { font-size: 13px; color: #aaa; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.05em; }
+  #info-content { font-size: 13px; color: #ccc; line-height: 1.6; }
+  #info-content .field { margin-bottom: 5px; }
+  #info-content .field b { color: #e0e0e0; }
+  #info-content .empty { color: #555; font-style: italic; }
+  .neighbor-link { display: block; padding: 2px 6px; margin: 2px 0; border-radius: 3px; cursor: pointer; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 3px solid #333; }
+  .neighbor-link:hover { background: #2a2a4e; }
+  #neighbors-list { max-height: 160px; overflow-y: auto; margin-top: 4px; }
+  #legend-wrap { flex: 1; overflow-y: auto; padding: 12px; }
+  #legend-wrap h3 { font-size: 13px; color: #aaa; margin-bottom: 10px; text-transform: uppercase; letter-spacing: 0.05em; }
+  .legend-item { display: flex; align-items: center; gap: 8px; padding: 4px 0; cursor: pointer; border-radius: 4px; font-size: 12px; }
+  .legend-item:hover { background: #2a2a4e; padding-left: 4px; }
+  .legend-item.dimmed { opacity: 0.35; }
+  .legend-dot { width: 12px; height: 12px; border-radius: 50%; flex-shrink: 0; }
+  .legend-label { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .legend-count { color: #666; font-size: 11px; }
+  #stats { padding: 10px 14px; border-top: 1px solid #2a2a4e; font-size: 11px; color: #555; }
+  #legend-controls { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; padding: 4px 0; }
+  #legend-controls label { display: flex; align-items: center; gap: 6px; cursor: pointer; font-size: 12px; color: #aaa; user-select: none; }
+  #legend-controls label:hover { color: #e0e0e0; }
+  .legend-cb, #select-all-cb { appearance: none; -webkit-appearance: none; width: 14px; height: 14px; border: 1.5px solid #3a3a5e; border-radius: 3px; background: #0f0f1a; cursor: pointer; position: relative; flex-shrink: 0; }
+  .legend-cb:checked, #select-all-cb:checked { background: #4E79A7; border-color: #4E79A7; }
+  .legend-cb:checked::after, #select-all-cb:checked::after { content: ''; position: absolute; left: 3.5px; top: 1px; width: 4px; height: 7px; border: solid #fff; border-width: 0 2px 2px 0; transform: rotate(45deg); }
+  #select-all-cb:indeterminate { background: #4E79A7; border-color: #4E79A7; }
+  #select-all-cb:indeterminate::after { content: ''; position: absolute; left: 2px; top: 5px; width: 8px; height: 2px; background: #fff; border: none; transform: none; }
+</style>
+</head>
+<body>
+<div id="graph"></div>
+<div id="sidebar">
+  <div id="search-wrap">
+    <input id="search" type="text" placeholder="Search nodes..." autocomplete="off">
+    <div id="search-results"></div>
+  </div>
+  <div id="info-panel">
+    <h3>Node Info</h3>
+    <div id="info-content"><span class="empty">Click a node to inspect it</span></div>
+  </div>
+  <div id="legend-wrap">
+    <h3>Communities</h3>
+    <div id="legend-controls">
+      <label><input type="checkbox" id="select-all-cb" checked onchange="toggleAllCommunities(!this.checked)">Select All</label>
+    </div>
+    <div id="legend"></div>
+  </div>
+  <div id="stats">27 nodes &middot; 21 edges &middot; 10 communities</div>
+</div>
+<script>
+const RAW_NODES = [{"id": "tailwind_config_mjs", "label": "tailwind.config.mjs", "color": {"background": "#B07AA1", "border": "#B07AA1", "highlight": {"background": "#ffffff", "border": "#B07AA1"}}, "size": 10.0, "font": {"size": 0, "color": "#ffffff"}, "title": "tailwind.config.mjs", "community": 6, "community_name": "Tailwind Configuration", "source_file": "tailwind.config.mjs", "file_type": "code", "degree": 0}, {"id": "astro_config_mjs", "label": "astro.config.mjs", "color": {"background": "#FF9DA7", "border": "#FF9DA7", "highlight": {"background": "#ffffff", "border": "#FF9DA7"}}, "size": 10.0, "font": {"size": 0, "color": "#ffffff"}, "title": "astro.config.mjs", "community": 7, "community_name": "Astro Configuration", "source_file": "astro.config.mjs", "file_type": "code", "degree": 0}, {"id": "src_consts_ts", "label": "consts.ts", "color": {"background": "#9C755F", "border": "#9C755F", "highlight": {"background": "#ffffff", "border": "#9C755F"}}, "size": 10.0, "font": {"size": 0, "color": "#ffffff"}, "title": "consts.ts", "community": 8, "community_name": "Constants", "source_file": "src/consts.ts", "file_type": "code", "degree": 0}, {"id": "src_pages_rss_xml_ts", "label": "rss.xml.ts", "color": {"background": "#76B7B2", "border": "#76B7B2", "highlight": {"background": "#ffffff", "border": "#76B7B2"}}, "size": 13.8, "font": {"size": 0, "color": "#ffffff"}, "title": "rss.xml.ts", "community": 3, "community_name": "RSS Generation", "source_file": "src/pages/rss.xml.ts", "file_type": "code", "degree": 1}, {"id": "pages_rss_xml_get", "label": "GET()", "color": {"background": "#76B7B2", "border": "#76B7B2", "highlight": {"background": "#ffffff", "border": "#76B7B2"}}, "size": 13.8, "font": {"size": 0, "color": "#ffffff"}, "title": "GET()", "community": 3, "community_name": "RSS Generation", "source_file": "src/pages/rss.xml.ts", "file_type": "code", "degree": 1}, {"id": "src_content_config_ts", "label": "config.ts", "color": {"background": "#BAB0AC", "border": "#BAB0AC", "highlight": {"background": "#ffffff", "border": "#BAB0AC"}}, "size": 10.0, "font": {"size": 0, "color": "#ffffff"}, "title": "config.ts", "community": 9, "community_name": "Content Configuration", "source_file": "src/content/config.ts", "file_type": "code", "degree": 0}, {"id": "src_lib_utils_ts", "label": "utils.ts", "color": {"background": "#F28E2B", "border": "#F28E2B", "highlight": {"background": "#ffffff", "border": "#F28E2B"}}, "size": 25.0, "font": {"size": 12, "color": "#ffffff"}, "title": "utils.ts", "community": 1, "community_name": "Utility Functions", "source_file": "src/lib/utils.ts", "file_type": "code", "degree": 4}, {"id": "lib_utils_getreadingtime", "label": "getReadingTime()", "color": {"background": "#F28E2B", "border": "#F28E2B", "highlight": {"background": "#ffffff", "border": "#F28E2B"}}, "size": 13.8, "font": {"size": 0, "color": "#ffffff"}, "title": "getReadingTime()", "community": 1, "community_name": "Utility Functions", "source_file": "src/lib/utils.ts", "file_type": "code", "degree": 1}, {"id": "lib_utils_getwordcount", "label": "getWordCount()", "color": {"background": "#F28E2B", "border": "#F28E2B", "highlight": {"background": "#ffffff", "border": "#F28E2B"}}, "size": 13.8, "font": {"size": 0, "color": "#ffffff"}, "title": "getWordCount()", "community": 1, "community_name": "Utility Functions", "source_file": "src/lib/utils.ts", "file_type": "code", "degree": 1}, {"id": "lib_utils_formatdate", "label": "formatDate()", "color": {"background": "#F28E2B", "border": "#F28E2B", "highlight": {"background": "#ffffff", "border": "#F28E2B"}}, "size": 13.8, "font": {"size": 0, "color": "#ffffff"}, "title": "formatDate()", "community": 1, "community_name": "Utility Functions", "source_file": "src/lib/utils.ts", "file_type": "code", "degree": 1}, {"id": "lib_utils_slugify", "label": "slugify()", "color": {"background": "#F28E2B", "border": "#F28E2B", "highlight": {"background": "#ffffff", "border": "#F28E2B"}}, "size": 13.8, "font": {"size": 0, "color": "#ffffff"}, "title": "slugify()", "community": 1, "community_name": "Utility Functions", "source_file": "src/lib/utils.ts", "file_type": "code", "degree": 1}, {"id": "src_lib_related_posts_ts", "label": "related-posts.ts", "color": {"background": "#59A14F", "border": "#59A14F", "highlight": {"background": "#ffffff", "border": "#59A14F"}}, "size": 13.8, "font": {"size": 0, "color": "#ffffff"}, "title": "related-posts.ts", "community": 4, "community_name": "Related Posts Logic", "source_file": "src/lib/related-posts.ts", "file_type": "code", "degree": 1}, {"id": "lib_related_posts_getrelatedposts", "label": "getRelatedPosts()", "color": {"background": "#59A14F", "border": "#59A14F", "highlight": {"background": "#ffffff", "border": "#59A14F"}}, "size": 13.8, "font": {"size": 0, "color": "#ffffff"}, "title": "getRelatedPosts()", "community": 4, "community_name": "Related Posts Logic", "source_file": "src/lib/related-posts.ts", "file_type": "code", "degree": 1}, {"id": "src_scripts_post_interactivity_js", "label": "post-interactivity.js", "color": {"background": "#E15759", "border": "#E15759", "highlight": {"background": "#ffffff", "border": "#E15759"}}, "size": 17.5, "font": {"size": 12, "color": "#ffffff"}, "title": "post-interactivity.js", "community": 2, "community_name": "Post Interactivity", "source_file": "src/scripts/post-interactivity.js", "file_type": "code", "degree": 2}, {"id": "scripts_post_interactivity_initpostinteractivity", "label": "initPostInteractivity()", "color": {"background": "#E15759", "border": "#E15759", "highlight": {"background": "#ffffff", "border": "#E15759"}}, "size": 17.5, "font": {"size": 12, "color": "#ffffff"}, "title": "initPostInteractivity()", "community": 2, "community_name": "Post Interactivity", "source_file": "src/scripts/post-interactivity.js", "file_type": "code", "degree": 2}, {"id": "scripts_post_interactivity_setupinteractivity", "label": "setupInteractivity()", "color": {"background": "#E15759", "border": "#E15759", "highlight": {"background": "#ffffff", "border": "#E15759"}}, "size": 17.5, "font": {"size": 12, "color": "#ffffff"}, "title": "setupInteractivity()", "community": 2, "community_name": "Post Interactivity", "source_file": "src/scripts/post-interactivity.js", "file_type": "code", "degree": 2}, {"id": "src_scripts_sidebar_nav_js", "label": "sidebar-nav.js", "color": {"background": "#EDC948", "border": "#EDC948", "highlight": {"background": "#ffffff", "border": "#EDC948"}}, "size": 13.8, "font": {"size": 0, "color": "#ffffff"}, "title": "sidebar-nav.js", "community": 5, "community_name": "Sidebar Navigation", "source_file": "src/scripts/sidebar-nav.js", "file_type": "code", "degree": 1}, {"id": "scripts_sidebar_nav_initsidebarnav", "label": "initSidebarNav()", "color": {"background": "#EDC948", "border": "#EDC948", "highlight": {"background": "#ffffff", "border": "#EDC948"}}, "size": 13.8, "font": {"size": 0, "color": "#ffffff"}, "title": "initSidebarNav()", "community": 5, "community_name": "Sidebar Navigation", "source_file": "src/scripts/sidebar-nav.js", "file_type": "code", "degree": 1}, {"id": "src_scripts_blog_filter_js", "label": "blog-filter.js", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 13.8, "font": {"size": 0, "color": "#ffffff"}, "title": "blog-filter.js", "community": 0, "community_name": "Blog Filtering Scripts", "source_file": "src/scripts/blog-filter.js", "file_type": "code", "degree": 1}, {"id": "scripts_blog_filter_blogfilter", "label": "BlogFilter", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 40.0, "font": {"size": 12, "color": "#ffffff"}, "title": "BlogFilter", "community": 0, "community_name": "Blog Filtering Scripts", "source_file": "src/scripts/blog-filter.js", "file_type": "code", "degree": 8}, {"id": "scripts_blog_filter_blogfilter_constructor", "label": ".constructor()", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 13.8, "font": {"size": 0, "color": "#ffffff"}, "title": ".constructor()", "community": 0, "community_name": "Blog Filtering Scripts", "source_file": "src/scripts/blog-filter.js", "file_type": "code", "degree": 1}, {"id": "scripts_blog_filter_blogfilter_connectedcallback", "label": ".connectedCallback()", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 25.0, "font": {"size": 12, "color": "#ffffff"}, "title": ".connectedCallback()", "community": 0, "community_name": "Blog Filtering Scripts", "source_file": "src/scripts/blog-filter.js", "file_type": "code", "degree": 4}, {"id": "scripts_blog_filter_blogfilter_bindevents", "label": ".bindEvents()", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 17.5, "font": {"size": 12, "color": "#ffffff"}, "title": ".bindEvents()", "community": 0, "community_name": "Blog Filtering Scripts", "source_file": "src/scripts/blog-filter.js", "file_type": "code", "degree": 2}, {"id": "scripts_blog_filter_blogfilter_syncfromurl", "label": ".syncFromURL()", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 17.5, "font": {"size": 12, "color": "#ffffff"}, "title": ".syncFromURL()", "community": 0, "community_name": "Blog Filtering Scripts", "source_file": "src/scripts/blog-filter.js", "file_type": "code", "degree": 2}, {"id": "scripts_blog_filter_blogfilter_updateurl", "label": ".updateURL()", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 13.8, "font": {"size": 0, "color": "#ffffff"}, "title": ".updateURL()", "community": 0, "community_name": "Blog Filtering Scripts", "source_file": "src/scripts/blog-filter.js", "file_type": "code", "degree": 1}, {"id": "scripts_blog_filter_blogfilter_filterandrender", "label": ".filterAndRender()", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 17.5, "font": {"size": 12, "color": "#ffffff"}, "title": ".filterAndRender()", "community": 0, "community_name": "Blog Filtering Scripts", "source_file": "src/scripts/blog-filter.js", "file_type": "code", "degree": 2}, {"id": "scripts_blog_filter_blogfilter_generatecardhtml", "label": ".generateCardHTML()", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 13.8, "font": {"size": 0, "color": "#ffffff"}, "title": ".generateCardHTML()", "community": 0, "community_name": "Blog Filtering Scripts", "source_file": "src/scripts/blog-filter.js", "file_type": "code", "degree": 1}];
+const RAW_EDGES = [{"from": "src_pages_rss_xml_ts", "to": "pages_rss_xml_get", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "src_lib_utils_ts", "to": "lib_utils_getreadingtime", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "src_lib_utils_ts", "to": "lib_utils_getwordcount", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "src_lib_utils_ts", "to": "lib_utils_formatdate", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "src_lib_utils_ts", "to": "lib_utils_slugify", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "src_lib_related_posts_ts", "to": "lib_related_posts_getrelatedposts", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "src_scripts_post_interactivity_js", "to": "scripts_post_interactivity_initpostinteractivity", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "src_scripts_post_interactivity_js", "to": "scripts_post_interactivity_setupinteractivity", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "scripts_post_interactivity_setupinteractivity", "to": "scripts_post_interactivity_initpostinteractivity", "label": "calls", "title": "calls [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "src_scripts_sidebar_nav_js", "to": "scripts_sidebar_nav_initsidebarnav", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "src_scripts_blog_filter_js", "to": "scripts_blog_filter_blogfilter", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "scripts_blog_filter_blogfilter", "to": "scripts_blog_filter_blogfilter_constructor", "label": "method", "title": "method [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "scripts_blog_filter_blogfilter", "to": "scripts_blog_filter_blogfilter_connectedcallback", "label": "method", "title": "method [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "scripts_blog_filter_blogfilter", "to": "scripts_blog_filter_blogfilter_bindevents", "label": "method", "title": "method [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "scripts_blog_filter_blogfilter", "to": "scripts_blog_filter_blogfilter_syncfromurl", "label": "method", "title": "method [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "scripts_blog_filter_blogfilter", "to": "scripts_blog_filter_blogfilter_updateurl", "label": "method", "title": "method [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "scripts_blog_filter_blogfilter", "to": "scripts_blog_filter_blogfilter_filterandrender", "label": "method", "title": "method [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "scripts_blog_filter_blogfilter", "to": "scripts_blog_filter_blogfilter_generatecardhtml", "label": "method", "title": "method [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "scripts_blog_filter_blogfilter_connectedcallback", "to": "scripts_blog_filter_blogfilter_bindevents", "label": "calls", "title": "calls [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "scripts_blog_filter_blogfilter_connectedcallback", "to": "scripts_blog_filter_blogfilter_syncfromurl", "label": "calls", "title": "calls [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "scripts_blog_filter_blogfilter_connectedcallback", "to": "scripts_blog_filter_blogfilter_filterandrender", "label": "calls", "title": "calls [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}];
+const LEGEND = [{"cid": 0, "color": "#4E79A7", "label": "Blog Filtering Scripts", "count": 9}, {"cid": 1, "color": "#F28E2B", "label": "Utility Functions", "count": 5}, {"cid": 2, "color": "#E15759", "label": "Post Interactivity", "count": 3}, {"cid": 3, "color": "#76B7B2", "label": "RSS Generation", "count": 2}, {"cid": 4, "color": "#59A14F", "label": "Related Posts Logic", "count": 2}, {"cid": 5, "color": "#EDC948", "label": "Sidebar Navigation", "count": 2}, {"cid": 6, "color": "#B07AA1", "label": "Tailwind Configuration", "count": 1}, {"cid": 7, "color": "#FF9DA7", "label": "Astro Configuration", "count": 1}, {"cid": 8, "color": "#9C755F", "label": "Constants", "count": 1}, {"cid": 9, "color": "#BAB0AC", "label": "Content Configuration", "count": 1}];
+
+// HTML-escape helper — prevents XSS when injecting graph data into innerHTML
+function esc(s) {
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
+
+// Build vis datasets
+const nodesDS = new vis.DataSet(RAW_NODES.map(n => ({
+  id: n.id, label: n.label, color: n.color, size: n.size,
+  font: n.font, title: n.title,
+  _community: n.community, _community_name: n.community_name,
+  _source_file: n.source_file, _file_type: n.file_type, _degree: n.degree,
+})));
+
+const edgesDS = new vis.DataSet(RAW_EDGES.map((e, i) => ({
+  id: i, from: e.from, to: e.to,
+  label: '',
+  title: e.title,
+  dashes: e.dashes,
+  width: e.width,
+  color: e.color,
+  arrows: { to: { enabled: true, scaleFactor: 0.5 } },
+})));
+
+const container = document.getElementById('graph');
+const network = new vis.Network(container, { nodes: nodesDS, edges: edgesDS }, {
+  physics: {
+    enabled: true,
+    solver: 'forceAtlas2Based',
+    forceAtlas2Based: {
+      gravitationalConstant: -60,
+      centralGravity: 0.005,
+      springLength: 120,
+      springConstant: 0.08,
+      damping: 0.4,
+      avoidOverlap: 0.8,
+    },
+    stabilization: { iterations: 200, fit: true },
+  },
+  interaction: {
+    hover: true,
+    tooltipDelay: 100,
+    hideEdgesOnDrag: true,
+    navigationButtons: false,
+    keyboard: false,
+  },
+  nodes: { shape: 'dot', borderWidth: 1.5 },
+  edges: { smooth: { type: 'continuous', roundness: 0.2 }, selectionWidth: 3 },
+});
+
+network.once('stabilizationIterationsDone', () => {
+  network.setOptions({ physics: { enabled: false } });
+});
+
+function showInfo(nodeId) {
+  const n = nodesDS.get(nodeId);
+  if (!n) return;
+  const neighborIds = network.getConnectedNodes(nodeId);
+  const neighborItems = neighborIds.map(nid => {
+    const nb = nodesDS.get(nid);
+    const color = nb ? nb.color.background : '#555';
+    return `<span class="neighbor-link" style="border-left-color:${esc(color)}" onclick="focusNode(${JSON.stringify(nid)})">${esc(nb ? nb.label : nid)}</span>`;
+  }).join('');
+  document.getElementById('info-content').innerHTML = `
+    <div class="field"><b>${esc(n.label)}</b></div>
+    <div class="field">Type: ${esc(n._file_type || 'unknown')}</div>
+    <div class="field">Community: ${esc(n._community_name)}</div>
+    <div class="field">Source: ${esc(n._source_file || '-')}</div>
+    <div class="field">Degree: ${n._degree}</div>
+    ${neighborIds.length ? `<div class="field" style="margin-top:8px;color:#aaa;font-size:11px">Neighbors (${neighborIds.length})</div><div id="neighbors-list">${neighborItems}</div>` : ''}
+  `;
+}
+
+function focusNode(nodeId) {
+  network.focus(nodeId, { scale: 1.4, animation: true });
+  network.selectNodes([nodeId]);
+  showInfo(nodeId);
+}
+
+// Track hovered node — hover detection is more reliable than click params
+let hoveredNodeId = null;
+network.on('hoverNode', params => {
+  hoveredNodeId = params.node;
+  container.style.cursor = 'pointer';
+});
+network.on('blurNode', () => {
+  hoveredNodeId = null;
+  container.style.cursor = 'default';
+});
+container.addEventListener('click', () => {
+  if (hoveredNodeId !== null) {
+    showInfo(hoveredNodeId);
+    network.selectNodes([hoveredNodeId]);
+  }
+});
+network.on('click', params => {
+  if (params.nodes.length > 0) {
+    showInfo(params.nodes[0]);
+  } else if (hoveredNodeId === null) {
+    document.getElementById('info-content').innerHTML = '<span class="empty">Click a node to inspect it</span>';
+  }
+});
+
+const searchInput = document.getElementById('search');
+const searchResults = document.getElementById('search-results');
+searchInput.addEventListener('input', () => {
+  const q = searchInput.value.toLowerCase().trim();
+  searchResults.innerHTML = '';
+  if (!q) { searchResults.style.display = 'none'; return; }
+  const matches = RAW_NODES.filter(n => n.label.toLowerCase().includes(q)).slice(0, 20);
+  if (!matches.length) { searchResults.style.display = 'none'; return; }
+  searchResults.style.display = 'block';
+  matches.forEach(n => {
+    const el = document.createElement('div');
+    el.className = 'search-item';
+    el.textContent = n.label;
+    el.style.borderLeft = `3px solid ${n.color.background}`;
+    el.style.paddingLeft = '8px';
+    el.onclick = () => {
+      network.focus(n.id, { scale: 1.5, animation: true });
+      network.selectNodes([n.id]);
+      showInfo(n.id);
+      searchResults.style.display = 'none';
+      searchInput.value = '';
+    };
+    searchResults.appendChild(el);
+  });
+});
+document.addEventListener('click', e => {
+  if (!searchResults.contains(e.target) && e.target !== searchInput)
+    searchResults.style.display = 'none';
+});
+
+const hiddenCommunities = new Set();
+
+const selectAllCb = document.getElementById('select-all-cb');
+
+function updateSelectAllState() {
+  const total = LEGEND.length;
+  const hidden = hiddenCommunities.size;
+  selectAllCb.checked = hidden === 0;
+  selectAllCb.indeterminate = hidden > 0 && hidden < total;
+}
+
+function toggleAllCommunities(hide) {
+  document.querySelectorAll('.legend-item').forEach(item => {
+    hide ? item.classList.add('dimmed') : item.classList.remove('dimmed');
+  });
+  document.querySelectorAll('.legend-cb').forEach(cb => {
+    cb.checked = !hide;
+  });
+  LEGEND.forEach(c => {
+    if (hide) hiddenCommunities.add(c.cid); else hiddenCommunities.delete(c.cid);
+  });
+  const updates = RAW_NODES.map(n => ({ id: n.id, hidden: hide }));
+  nodesDS.update(updates);
+  updateSelectAllState();
+}
+
+const legendEl = document.getElementById('legend');
+LEGEND.forEach(c => {
+  const item = document.createElement('div');
+  item.className = 'legend-item';
+  const cb = document.createElement('input');
+  cb.type = 'checkbox';
+  cb.className = 'legend-cb';
+  cb.checked = true;
+  cb.addEventListener('change', (e) => {
+    e.stopPropagation();
+    if (cb.checked) {
+      hiddenCommunities.delete(c.cid);
+      item.classList.remove('dimmed');
+    } else {
+      hiddenCommunities.add(c.cid);
+      item.classList.add('dimmed');
+    }
+    const updates = RAW_NODES
+      .filter(n => n.community === c.cid)
+      .map(n => ({ id: n.id, hidden: !cb.checked }));
+    nodesDS.update(updates);
+    updateSelectAllState();
+  });
+  item.innerHTML = `<div class="legend-dot" style="background:${c.color}"></div>
+    <span class="legend-label">${c.label}</span>
+    <span class="legend-count">${c.count}</span>`;
+  item.prepend(cb);
+  item.onclick = (e) => {
+    if (e.target === cb) return;
+    cb.checked = !cb.checked;
+    cb.dispatchEvent(new Event('change'));
+  };
+  legendEl.appendChild(item);
+});
+</script>
+<script>
+// Render hyperedges as shaded regions
+const hyperedges = [];
+// afterDrawing passes ctx already transformed to network coordinate space.
+// Draw node positions raw — no manual pan/zoom/DPR math needed.
+network.on('afterDrawing', function(ctx) {
+    hyperedges.forEach(h => {
+        const positions = h.nodes
+            .map(nid => network.getPositions([nid])[nid])
+            .filter(p => p !== undefined);
+        if (positions.length < 2) return;
+        ctx.save();
+        ctx.globalAlpha = 0.12;
+        ctx.fillStyle = '#6366f1';
+        ctx.strokeStyle = '#6366f1';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        // Centroid and expanded hull in network coordinates
+        const cx = positions.reduce((s, p) => s + p.x, 0) / positions.length;
+        const cy = positions.reduce((s, p) => s + p.y, 0) / positions.length;
+        const expanded = positions.map(p => ({
+            x: cx + (p.x - cx) * 1.15,
+            y: cy + (p.y - cy) * 1.15
+        }));
+        ctx.moveTo(expanded[0].x, expanded[0].y);
+        expanded.slice(1).forEach(p => ctx.lineTo(p.x, p.y));
+        ctx.closePath();
+        ctx.fill();
+        ctx.globalAlpha = 0.4;
+        ctx.stroke();
+        // Label
+        ctx.globalAlpha = 0.8;
+        ctx.fillStyle = '#4f46e5';
+        ctx.font = 'bold 11px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText(h.label, cx, cy - 5);
+        ctx.restore();
+    });
+});
+</script>
+</body>
+</html>

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1,0 +1,467 @@
+{
+  "directed": false,
+  "multigraph": false,
+  "graph": {},
+  "nodes": [
+    {
+      "label": "tailwind.config.mjs",
+      "file_type": "code",
+      "source_file": "tailwind.config.mjs",
+      "source_location": "L1",
+      "id": "tailwind_config_mjs",
+      "community": 6,
+      "norm_label": "tailwind.config.mjs"
+    },
+    {
+      "label": "astro.config.mjs",
+      "file_type": "code",
+      "source_file": "astro.config.mjs",
+      "source_location": "L1",
+      "id": "astro_config_mjs",
+      "community": 7,
+      "norm_label": "astro.config.mjs"
+    },
+    {
+      "label": "consts.ts",
+      "file_type": "code",
+      "source_file": "src/consts.ts",
+      "source_location": "L1",
+      "id": "src_consts_ts",
+      "community": 8,
+      "norm_label": "consts.ts"
+    },
+    {
+      "label": "rss.xml.ts",
+      "file_type": "code",
+      "source_file": "src/pages/rss.xml.ts",
+      "source_location": "L1",
+      "id": "src_pages_rss_xml_ts",
+      "community": 3,
+      "norm_label": "rss.xml.ts"
+    },
+    {
+      "label": "GET()",
+      "file_type": "code",
+      "source_file": "src/pages/rss.xml.ts",
+      "source_location": "L6",
+      "id": "pages_rss_xml_get",
+      "community": 3,
+      "norm_label": "get()"
+    },
+    {
+      "label": "config.ts",
+      "file_type": "code",
+      "source_file": "src/content/config.ts",
+      "source_location": "L1",
+      "id": "src_content_config_ts",
+      "community": 9,
+      "norm_label": "config.ts"
+    },
+    {
+      "label": "utils.ts",
+      "file_type": "code",
+      "source_file": "src/lib/utils.ts",
+      "source_location": "L1",
+      "id": "src_lib_utils_ts",
+      "community": 1,
+      "norm_label": "utils.ts"
+    },
+    {
+      "label": "getReadingTime()",
+      "file_type": "code",
+      "source_file": "src/lib/utils.ts",
+      "source_location": "L3",
+      "id": "lib_utils_getreadingtime",
+      "community": 1,
+      "norm_label": "getreadingtime()"
+    },
+    {
+      "label": "getWordCount()",
+      "file_type": "code",
+      "source_file": "src/lib/utils.ts",
+      "source_location": "L8",
+      "id": "lib_utils_getwordcount",
+      "community": 1,
+      "norm_label": "getwordcount()"
+    },
+    {
+      "label": "formatDate()",
+      "file_type": "code",
+      "source_file": "src/lib/utils.ts",
+      "source_location": "L13",
+      "id": "lib_utils_formatdate",
+      "community": 1,
+      "norm_label": "formatdate()"
+    },
+    {
+      "label": "slugify()",
+      "file_type": "code",
+      "source_file": "src/lib/utils.ts",
+      "source_location": "L21",
+      "id": "lib_utils_slugify",
+      "community": 1,
+      "norm_label": "slugify()"
+    },
+    {
+      "label": "related-posts.ts",
+      "file_type": "code",
+      "source_file": "src/lib/related-posts.ts",
+      "source_location": "L1",
+      "id": "src_lib_related_posts_ts",
+      "community": 4,
+      "norm_label": "related-posts.ts"
+    },
+    {
+      "label": "getRelatedPosts()",
+      "file_type": "code",
+      "source_file": "src/lib/related-posts.ts",
+      "source_location": "L11",
+      "id": "lib_related_posts_getrelatedposts",
+      "community": 4,
+      "norm_label": "getrelatedposts()"
+    },
+    {
+      "label": "post-interactivity.js",
+      "file_type": "code",
+      "source_file": "src/scripts/post-interactivity.js",
+      "source_location": "L1",
+      "id": "src_scripts_post_interactivity_js",
+      "community": 2,
+      "norm_label": "post-interactivity.js"
+    },
+    {
+      "label": "initPostInteractivity()",
+      "file_type": "code",
+      "source_file": "src/scripts/post-interactivity.js",
+      "source_location": "L1",
+      "id": "scripts_post_interactivity_initpostinteractivity",
+      "community": 2,
+      "norm_label": "initpostinteractivity()"
+    },
+    {
+      "label": "setupInteractivity()",
+      "file_type": "code",
+      "source_file": "src/scripts/post-interactivity.js",
+      "source_location": "L180",
+      "id": "scripts_post_interactivity_setupinteractivity",
+      "community": 2,
+      "norm_label": "setupinteractivity()"
+    },
+    {
+      "label": "sidebar-nav.js",
+      "file_type": "code",
+      "source_file": "src/scripts/sidebar-nav.js",
+      "source_location": "L1",
+      "id": "src_scripts_sidebar_nav_js",
+      "community": 5,
+      "norm_label": "sidebar-nav.js"
+    },
+    {
+      "label": "initSidebarNav()",
+      "file_type": "code",
+      "source_file": "src/scripts/sidebar-nav.js",
+      "source_location": "L7",
+      "id": "scripts_sidebar_nav_initsidebarnav",
+      "community": 5,
+      "norm_label": "initsidebarnav()"
+    },
+    {
+      "label": "blog-filter.js",
+      "file_type": "code",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L1",
+      "id": "src_scripts_blog_filter_js",
+      "community": 0,
+      "norm_label": "blog-filter.js"
+    },
+    {
+      "label": "BlogFilter",
+      "file_type": "code",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L1",
+      "id": "scripts_blog_filter_blogfilter",
+      "community": 0,
+      "norm_label": "blogfilter"
+    },
+    {
+      "label": ".constructor()",
+      "file_type": "code",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L2",
+      "id": "scripts_blog_filter_blogfilter_constructor",
+      "community": 0,
+      "norm_label": ".constructor()"
+    },
+    {
+      "label": ".connectedCallback()",
+      "file_type": "code",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L11",
+      "id": "scripts_blog_filter_blogfilter_connectedcallback",
+      "community": 0,
+      "norm_label": ".connectedcallback()"
+    },
+    {
+      "label": ".bindEvents()",
+      "file_type": "code",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L41",
+      "id": "scripts_blog_filter_blogfilter_bindevents",
+      "community": 0,
+      "norm_label": ".bindevents()"
+    },
+    {
+      "label": ".syncFromURL()",
+      "file_type": "code",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L100",
+      "id": "scripts_blog_filter_blogfilter_syncfromurl",
+      "community": 0,
+      "norm_label": ".syncfromurl()"
+    },
+    {
+      "label": ".updateURL()",
+      "file_type": "code",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L122",
+      "id": "scripts_blog_filter_blogfilter_updateurl",
+      "community": 0,
+      "norm_label": ".updateurl()"
+    },
+    {
+      "label": ".filterAndRender()",
+      "file_type": "code",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L134",
+      "id": "scripts_blog_filter_blogfilter_filterandrender",
+      "community": 0,
+      "norm_label": ".filterandrender()"
+    },
+    {
+      "label": ".generateCardHTML()",
+      "file_type": "code",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L170",
+      "id": "scripts_blog_filter_blogfilter_generatecardhtml",
+      "community": 0,
+      "norm_label": ".generatecardhtml()"
+    }
+  ],
+  "links": [
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/pages/rss.xml.ts",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "src_pages_rss_xml_ts",
+      "target": "pages_rss_xml_get",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/lib/utils.ts",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_lib_utils_ts",
+      "target": "lib_utils_getreadingtime",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/lib/utils.ts",
+      "source_location": "L8",
+      "weight": 1.0,
+      "source": "src_lib_utils_ts",
+      "target": "lib_utils_getwordcount",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/lib/utils.ts",
+      "source_location": "L13",
+      "weight": 1.0,
+      "source": "src_lib_utils_ts",
+      "target": "lib_utils_formatdate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/lib/utils.ts",
+      "source_location": "L21",
+      "weight": 1.0,
+      "source": "src_lib_utils_ts",
+      "target": "lib_utils_slugify",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/lib/related-posts.ts",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "src_lib_related_posts_ts",
+      "target": "lib_related_posts_getrelatedposts",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scripts/post-interactivity.js",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "src_scripts_post_interactivity_js",
+      "target": "scripts_post_interactivity_initpostinteractivity",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scripts/post-interactivity.js",
+      "source_location": "L180",
+      "weight": 1.0,
+      "source": "src_scripts_post_interactivity_js",
+      "target": "scripts_post_interactivity_setupinteractivity",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scripts/post-interactivity.js",
+      "source_location": "L181",
+      "weight": 1.0,
+      "source": "scripts_post_interactivity_setupinteractivity",
+      "target": "scripts_post_interactivity_initpostinteractivity",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scripts/sidebar-nav.js",
+      "source_location": "L7",
+      "weight": 1.0,
+      "source": "src_scripts_sidebar_nav_js",
+      "target": "scripts_sidebar_nav_initsidebarnav",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "src_scripts_blog_filter_js",
+      "target": "scripts_blog_filter_blogfilter",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "scripts_blog_filter_blogfilter",
+      "target": "scripts_blog_filter_blogfilter_constructor",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "scripts_blog_filter_blogfilter",
+      "target": "scripts_blog_filter_blogfilter_connectedcallback",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L41",
+      "weight": 1.0,
+      "source": "scripts_blog_filter_blogfilter",
+      "target": "scripts_blog_filter_blogfilter_bindevents",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L100",
+      "weight": 1.0,
+      "source": "scripts_blog_filter_blogfilter",
+      "target": "scripts_blog_filter_blogfilter_syncfromurl",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L122",
+      "weight": 1.0,
+      "source": "scripts_blog_filter_blogfilter",
+      "target": "scripts_blog_filter_blogfilter_updateurl",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L134",
+      "weight": 1.0,
+      "source": "scripts_blog_filter_blogfilter",
+      "target": "scripts_blog_filter_blogfilter_filterandrender",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L170",
+      "weight": 1.0,
+      "source": "scripts_blog_filter_blogfilter",
+      "target": "scripts_blog_filter_blogfilter_generatecardhtml",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L32",
+      "weight": 1.0,
+      "source": "scripts_blog_filter_blogfilter_connectedcallback",
+      "target": "scripts_blog_filter_blogfilter_bindevents",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L35",
+      "weight": 1.0,
+      "source": "scripts_blog_filter_blogfilter_connectedcallback",
+      "target": "scripts_blog_filter_blogfilter_syncfromurl",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scripts/blog-filter.js",
+      "source_location": "L38",
+      "weight": 1.0,
+      "source": "scripts_blog_filter_blogfilter_connectedcallback",
+      "target": "scripts_blog_filter_blogfilter_filterandrender",
+      "confidence_score": 1.0
+    }
+  ],
+  "hyperedges": []
+}


### PR DESCRIPTION
Closes #89

Add graphify-out outputs: `GRAPH_REPORT.md`, `graph.json`, and `graph.html`. 
The intermediate files in `graphify-out/` are ignored.